### PR TITLE
Rate limiting and lockout on auth endpoints (#16)

### DIFF
--- a/healthcare/pom.xml
+++ b/healthcare/pom.xml
@@ -87,6 +87,17 @@
             <scope>runtime</scope>
         </dependency>
 
+        <!-- Rate limiting (issue #16) -->
+        <dependency>
+            <groupId>com.bucket4j</groupId>
+            <artifactId>bucket4j_jdk17-core</artifactId>
+            <version>8.14.0</version>
+        </dependency>
+        <dependency>
+            <groupId>com.github.ben-manes.caffeine</groupId>
+            <artifactId>caffeine</artifactId>
+        </dependency>
+
         <!-- Swagger -->
         <dependency>
             <groupId>org.springdoc</groupId>

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/config/SecurityConfig.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/config/SecurityConfig.kt
@@ -2,6 +2,9 @@
 
 import com.lakshay.healthcare.shared.security.AuthEntryPoint
 import com.lakshay.healthcare.shared.security.JwtAuthFilter
+import com.lakshay.healthcare.shared.security.RateLimitFilter
+import org.springframework.beans.factory.annotation.Value
+import java.time.Duration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpMethod
@@ -17,7 +20,9 @@ import org.springframework.security.web.authentication.UsernamePasswordAuthentic
 @EnableWebSecurity
 class SecurityConfig(
     private val jwtAuthFilter: JwtAuthFilter,
-    private val authEntryPoint: AuthEntryPoint
+    private val authEntryPoint: AuthEntryPoint,
+    @Value("\${app.auth-throttle.ip-limit:10}") private val ipLimit: Long,
+    @Value("\${app.auth-throttle.ip-window-minutes:15}") private val ipWindowMinutes: Long
 ) {
 
     @Bean
@@ -57,6 +62,8 @@ class SecurityConfig(
                     .anyRequest().authenticated()
             }
             .addFilterBefore(jwtAuthFilter, UsernamePasswordAuthenticationFilter::class.java)
+            // brute-force throttle sits in front of everything else on the auth endpoints
+            .addFilterBefore(RateLimitFilter(ipLimit, Duration.ofMinutes(ipWindowMinutes)), JwtAuthFilter::class.java)
 
         return http.build()
     }

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/exception/Exceptions.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/exception/Exceptions.kt
@@ -11,3 +11,8 @@ class UnauthorizedException(message: String) : RuntimeException(message)
 class ValidationException(message: String) : RuntimeException(message)
 
 class ForbiddenException(message: String) : RuntimeException(message)
+
+class AccountLockedException(
+    val retryAfterSeconds: Long,
+    message: String = "Too many failed attempts. Try again later."
+) : RuntimeException(message)

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/exception/GlobalExceptionHandler.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/exception/GlobalExceptionHandler.kt
@@ -42,6 +42,19 @@ class GlobalExceptionHandler {
     fun handleValidation(ex: ValidationException): ResponseEntity<ErrorResponse> =
         errorResponse(HttpStatus.BAD_REQUEST, ex.message ?: "Bad request")
 
+    @ExceptionHandler(AccountLockedException::class)
+    fun handleAccountLocked(ex: AccountLockedException): ResponseEntity<ErrorResponse> =
+        ResponseEntity.status(HttpStatus.TOO_MANY_REQUESTS)
+            .header("Retry-After", ex.retryAfterSeconds.toString())
+            .body(
+                ErrorResponse(
+                    status = HttpStatus.TOO_MANY_REQUESTS.value(),
+                    error = HttpStatus.TOO_MANY_REQUESTS.reasonPhrase,
+                    message = ex.message ?: "Too many failed attempts",
+                    timestamp = LocalDateTime.now().toString()
+                )
+            )
+
     @ExceptionHandler(MaxUploadSizeExceededException::class)
     fun handleUploadTooLarge(ex: MaxUploadSizeExceededException): ResponseEntity<ErrorResponse> =
         errorResponse(HttpStatus.PAYLOAD_TOO_LARGE, "File too large")

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/security/LoginAttemptService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/security/LoginAttemptService.kt
@@ -1,0 +1,57 @@
+package com.lakshay.healthcare.shared.security
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import org.slf4j.LoggerFactory
+import org.springframework.beans.factory.annotation.Value
+import org.springframework.stereotype.Service
+import java.time.Duration
+import java.time.Instant
+import java.util.concurrent.atomic.AtomicInteger
+
+// Failed-login counter per email with temp lockout. In-memory on purpose:
+// single-node app, counters are throwaway defense, not domain data.
+@Service
+class LoginAttemptService(
+    @Value("\${app.auth-throttle.max-failures:5}") private val maxFailures: Int,
+    @Value("\${app.auth-throttle.lockout-minutes:15}") private val lockoutMinutes: Long
+) {
+    private val log = LoggerFactory.getLogger(LoginAttemptService::class.java)
+
+    private class Attempts {
+        val failures = AtomicInteger()
+        @Volatile
+        var lockedUntil: Instant? = null
+    }
+
+    private val attempts = Caffeine.newBuilder()
+        .expireAfterWrite(Duration.ofMinutes(lockoutMinutes))
+        .maximumSize(100_000)
+        .build<String, Attempts>()
+
+    // static value, not remaining time — don't leak lock age per account
+    fun lockoutSeconds(): Long = lockoutMinutes * 60
+
+    fun isLocked(email: String): Boolean {
+        val until = attempts.getIfPresent(key(email))?.lockedUntil ?: return false
+        return Instant.now().isBefore(until)
+    }
+
+    fun recordFailure(email: String) {
+        val k = key(email)
+        val a = attempts.get(k) { Attempts() }
+        // re-read volatile right before increment — narrows the lock/increment race
+        if (a.lockedUntil?.let { Instant.now().isBefore(it) } == true) return
+        if (a.failures.incrementAndGet() >= maxFailures) {
+            a.lockedUntil = Instant.now().plus(Duration.ofMinutes(lockoutMinutes))
+            a.failures.set(0)
+            log.warn("Account lockout: {} locked for {} min after {} failed logins", k, lockoutMinutes, maxFailures)
+        }
+        attempts.put(k, a) // refresh write timestamp so the window slides
+    }
+
+    fun recordSuccess(email: String) {
+        attempts.invalidate(key(email))
+    }
+
+    private fun key(email: String) = email.trim().lowercase()
+}

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/security/RateLimitFilter.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/security/RateLimitFilter.kt
@@ -1,0 +1,65 @@
+package com.lakshay.healthcare.shared.security
+
+import com.github.benmanes.caffeine.cache.Caffeine
+import com.github.benmanes.caffeine.cache.LoadingCache
+import io.github.bucket4j.Bandwidth
+import io.github.bucket4j.Bucket
+import io.github.bucket4j.Refill
+import jakarta.servlet.FilterChain
+import jakarta.servlet.http.HttpServletRequest
+import jakarta.servlet.http.HttpServletResponse
+import org.springframework.http.HttpStatus
+import org.springframework.http.MediaType
+import org.springframework.web.filter.OncePerRequestFilter
+import java.time.Duration
+
+// Per-IP throttle on the public auth endpoints. Deliberately NOT a @Component:
+// SecurityConfig news it up into the security chain only — a Filter bean would
+// get auto-registered a second time in the servlet chain and eat 2 tokens per hit.
+class RateLimitFilter(
+    private val limit: Long,
+    private val window: Duration
+) : OncePerRequestFilter() {
+
+    companion object {
+        val AUTH_PATHS = setOf(
+            "/api/auth/login",
+            "/user-api/login",
+            "/user-api/activate",
+            "/worker-api/login",
+            "/worker-api/activate"
+        )
+    }
+
+    private val buckets: LoadingCache<String, Bucket> = Caffeine.newBuilder()
+        .expireAfterAccess(window.multipliedBy(2))
+        .maximumSize(100_000) // spoofed-IP flood shouldn't OOM us
+        .build { _ ->
+            Bucket.builder()
+                .addLimit(Bandwidth.classic(limit, Refill.intervally(limit, window)))
+                .build()
+        }
+
+    override fun shouldNotFilter(request: HttpServletRequest): Boolean =
+        request.method != "POST" || request.requestURI.trimEnd('/') !in AUTH_PATHS
+
+    override fun doFilterInternal(
+        request: HttpServletRequest,
+        response: HttpServletResponse,
+        filterChain: FilterChain
+    ) {
+        // remoteAddr on purpose — X-Forwarded-For is client-spoofable, no trusted proxy here
+        val probe = buckets.get(request.remoteAddr).tryConsumeAndReturnRemaining(1)
+        if (probe.isConsumed) {
+            filterChain.doFilter(request, response)
+            return
+        }
+        val retryAfter = Duration.ofNanos(probe.nanosToWaitForRefill).seconds + 1
+        response.status = HttpStatus.TOO_MANY_REQUESTS.value()
+        response.setHeader("Retry-After", retryAfter.toString())
+        response.contentType = MediaType.APPLICATION_JSON_VALUE
+        response.writer.write(
+            """{"status":429,"error":"Too Many Requests","message":"Too many attempts. Try again later."}"""
+        )
+    }
+}

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/user/controller/AuthController.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/user/controller/AuthController.kt
@@ -5,7 +5,9 @@ import com.lakshay.healthcare.user.dto.LoginResponse
 import com.lakshay.healthcare.user.service.UserMgmtService
 import com.lakshay.healthcare.user.service.WorkerMgmtService
 import com.lakshay.healthcare.shared.entity.AdminMaster
+import com.lakshay.healthcare.shared.exception.AccountLockedException
 import com.lakshay.healthcare.shared.exception.UnauthorizedException
+import com.lakshay.healthcare.shared.security.LoginAttemptService
 import com.lakshay.healthcare.shared.repository.AdminMasterRepository
 import com.lakshay.healthcare.shared.repository.UserMasterRepository
 import com.lakshay.healthcare.shared.repository.WorkerMasterRepository
@@ -24,11 +26,16 @@ class AuthController(
     private val userService: UserMgmtService,
     private val workerService: WorkerMgmtService,
     private val jwtUtil: JwtUtil,
-    private val passwordEncoder: PasswordEncoder
+    private val passwordEncoder: PasswordEncoder,
+    private val loginAttemptService: LoginAttemptService
 ) {
 
     @PostMapping("/login")
     fun login(@RequestBody request: LoginRequest): ResponseEntity<Map<String, Any>> {
+        // must stay outside the try — the catch below eats everything into a 500
+        if (loginAttemptService.isLocked(request.email)) {
+            throw AccountLockedException(loginAttemptService.lockoutSeconds())
+        }
         return try {
             var name = ""
             var userType = "USER"
@@ -36,6 +43,7 @@ class AuthController(
             val admin = adminRepository.findByEmail(request.email)
             if (admin != null) {
                 if (!passwordEncoder.matches(request.password, admin.password)) {
+                    loginAttemptService.recordFailure(request.email)
                     return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                         .body(mapOf("error" to "Invalid email or password"))
                 }
@@ -45,6 +53,7 @@ class AuthController(
                 val worker = workerRepository.findByEmail(request.email)
                 if (worker != null) {
                     if (!passwordEncoder.matches(request.password, worker.password)) {
+                        loginAttemptService.recordFailure(request.email)
                         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                             .body(mapOf("error" to "Invalid email or password"))
                     }
@@ -57,10 +66,12 @@ class AuthController(
                 } else {
                     val user = userRepository.findByEmail(request.email)
                     if (user == null) {
+                        loginAttemptService.recordFailure(request.email)
                         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                             .body(mapOf("error" to "Invalid email or password"))
                     }
                     if (!passwordEncoder.matches(request.password, user.password)) {
+                        loginAttemptService.recordFailure(request.email)
                         return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
                             .body(mapOf("error" to "Invalid email or password"))
                     }
@@ -73,6 +84,7 @@ class AuthController(
                 }
             }
 
+            loginAttemptService.recordSuccess(request.email)
             val token = jwtUtil.generateToken(request.email, "ROLE_$userType")
 
             ResponseEntity.ok(

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/user/service/UserMgmtService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/user/service/UserMgmtService.kt
@@ -11,7 +11,9 @@ import com.lakshay.healthcare.user.dto.LoginResponse
 import com.lakshay.healthcare.user.dto.RegisterRequest
 import com.lakshay.healthcare.shared.exception.DuplicateResourceException
 import com.lakshay.healthcare.shared.exception.ResourceNotFoundException
+import com.lakshay.healthcare.shared.exception.AccountLockedException
 import com.lakshay.healthcare.shared.exception.UnauthorizedException
+import com.lakshay.healthcare.shared.security.LoginAttemptService
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import java.security.SecureRandom
@@ -28,7 +30,8 @@ class UserMgmtService(
     private val userRepository: UserMasterRepository,
     private val passwordEncoder: PasswordEncoder,
     private val jwtUtil: JwtUtil,
-    private val emailUtils: EmailUtils
+    private val emailUtils: EmailUtils,
+    private val loginAttemptService: LoginAttemptService
 ) {
 
     fun registerUser(request: RegisterRequest): RegistrationResult = register(request, "USER")
@@ -87,10 +90,18 @@ class UserMgmtService(
     }
 
     fun loginUser(request: LoginRequest): LoginResponse {
+        if (loginAttemptService.isLocked(request.email)) {
+            throw AccountLockedException(loginAttemptService.lockoutSeconds())
+        }
+
         val user = userRepository.findByEmail(request.email)
-            ?: throw UnauthorizedException("Invalid email or password")
+            ?: run {
+                loginAttemptService.recordFailure(request.email)
+                throw UnauthorizedException("Invalid email or password")
+            }
 
         if (!passwordEncoder.matches(request.password, user.password)) {
+            loginAttemptService.recordFailure(request.email)
             throw UnauthorizedException("Invalid email or password")
         }
 
@@ -98,6 +109,7 @@ class UserMgmtService(
             throw UnauthorizedException("Account not activated. Please activate your account first.")
         }
 
+        loginAttemptService.recordSuccess(request.email)
         val token = jwtUtil.generateToken(user.email, "ROLE_${user.role}")
         return LoginResponse(
             token = token,

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/user/service/WorkerMgmtService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/user/service/WorkerMgmtService.kt
@@ -11,7 +11,9 @@ import com.lakshay.healthcare.user.dto.LoginResponse
 import com.lakshay.healthcare.user.dto.RegisterRequest
 import com.lakshay.healthcare.shared.exception.DuplicateResourceException
 import com.lakshay.healthcare.shared.exception.ResourceNotFoundException
+import com.lakshay.healthcare.shared.exception.AccountLockedException
 import com.lakshay.healthcare.shared.exception.UnauthorizedException
+import com.lakshay.healthcare.shared.security.LoginAttemptService
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import java.security.SecureRandom
@@ -28,7 +30,8 @@ class WorkerMgmtService(
     private val workerRepository: WorkerMasterRepository,
     private val passwordEncoder: PasswordEncoder,
     private val jwtUtil: JwtUtil,
-    private val emailUtils: EmailUtils
+    private val emailUtils: EmailUtils,
+    private val loginAttemptService: LoginAttemptService
 ) {
 
     fun registerWorker(request: RegisterRequest): WorkerRegistrationResult {
@@ -86,10 +89,18 @@ class WorkerMgmtService(
     }
 
     fun loginWorker(request: LoginRequest): LoginResponse {
+        if (loginAttemptService.isLocked(request.email)) {
+            throw AccountLockedException(loginAttemptService.lockoutSeconds())
+        }
+
         val worker = workerRepository.findByEmail(request.email)
-            ?: throw UnauthorizedException("Invalid email or password")
+            ?: run {
+                loginAttemptService.recordFailure(request.email)
+                throw UnauthorizedException("Invalid email or password")
+            }
 
         if (!passwordEncoder.matches(request.password, worker.password)) {
+            loginAttemptService.recordFailure(request.email)
             throw UnauthorizedException("Invalid email or password")
         }
 
@@ -97,6 +108,7 @@ class WorkerMgmtService(
             throw UnauthorizedException("Account not activated. Please activate your account first.")
         }
 
+        loginAttemptService.recordSuccess(request.email)
         val token = jwtUtil.generateToken(worker.email, "ROLE_${worker.role}")
         return LoginResponse(
             token = token,

--- a/healthcare/src/main/resources/application.yml
+++ b/healthcare/src/main/resources/application.yml
@@ -48,6 +48,11 @@ jwt:
   audience: ish-services
 
 app:
+  auth-throttle:
+    ip-limit: 10           # POSTs per window per IP across the auth endpoints
+    ip-window-minutes: 15
+    max-failures: 5        # bad logins per email before temp lockout
+    lockout-minutes: 15
   cors:
     # Allowed origins, comma-separated. "*" = all (dev only) — lock down in prod
     # via APP_CORS_ALLOWED_ORIGINS=https://app.example.com,https://admin.example.com

--- a/healthcare/src/test/kotlin/com/lakshay/healthcare/shared/security/RateLimitingTests.kt
+++ b/healthcare/src/test/kotlin/com/lakshay/healthcare/shared/security/RateLimitingTests.kt
@@ -1,0 +1,73 @@
+package com.lakshay.healthcare.shared.security
+
+import org.junit.jupiter.api.Test
+import org.springframework.http.HttpStatus
+import org.springframework.mock.web.MockFilterChain
+import org.springframework.mock.web.MockHttpServletRequest
+import org.springframework.mock.web.MockHttpServletResponse
+import java.time.Duration
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+
+class RateLimitingTests {
+
+    @Test
+    fun `locks account after max failures`() {
+        val svc = LoginAttemptService(maxFailures = 3, lockoutMinutes = 15L)
+        repeat(2) { svc.recordFailure("a@b.com") }
+        assertFalse(svc.isLocked("a@b.com"))
+        svc.recordFailure("a@b.com")
+        assertTrue(svc.isLocked("a@b.com"))
+        assertFalse(svc.isLocked("other@b.com"))
+    }
+
+    @Test
+    fun `success resets failure count`() {
+        val svc = LoginAttemptService(maxFailures = 3, lockoutMinutes = 15L)
+        repeat(2) { svc.recordFailure("a@b.com") }
+        svc.recordSuccess("a@b.com")
+        repeat(2) { svc.recordFailure("a@b.com") }
+        assertFalse(svc.isLocked("a@b.com"))
+    }
+
+    @Test
+    fun `tracks unknown emails too`() {
+        val svc = LoginAttemptService(maxFailures = 1, lockoutMinutes = 15L)
+        svc.recordFailure("ghost@nowhere.com")
+        assertTrue(svc.isLocked("ghost@nowhere.com"))
+    }
+
+    @Test
+    fun `ip bucket returns 429 with Retry-After then refills`() {
+        val filter = RateLimitFilter(limit = 2, window = Duration.ofSeconds(1))
+
+        fun fire(): MockHttpServletResponse {
+            val req = MockHttpServletRequest("POST", "/api/auth/login")
+            val res = MockHttpServletResponse()
+            filter.doFilter(req, res, MockFilterChain())
+            return res
+        }
+
+        assertEquals(HttpStatus.OK.value(), fire().status)
+        assertEquals(HttpStatus.OK.value(), fire().status)
+        val limited = fire()
+        assertEquals(HttpStatus.TOO_MANY_REQUESTS.value(), limited.status)
+        assertNotNull(limited.getHeader("Retry-After"))
+
+        Thread.sleep(1200) // window refill
+        assertEquals(HttpStatus.OK.value(), fire().status)
+    }
+
+    @Test
+    fun `non-auth paths skip the filter`() {
+        val filter = RateLimitFilter(limit = 1, window = Duration.ofMinutes(15))
+        repeat(3) {
+            val req = MockHttpServletRequest("GET", "/plan-api/categories")
+            val res = MockHttpServletResponse()
+            filter.doFilter(req, res, MockFilterChain())
+            assertEquals(HttpStatus.OK.value(), res.status)
+        }
+    }
+}

--- a/healthcare/src/test/resources/application-test.yml
+++ b/healthcare/src/test/resources/application-test.yml
@@ -32,3 +32,10 @@ jwt:
   # Test-only secret so the suite doesn't need JWT_SECRET set. Not for prod —
   # prod has no default and must supply its own.
   secret: test-only-jwt-secret-not-for-production-use-min-256-bits-0123456789
+
+# ITs fire everything from one IP through MockMvc — real thresholds would trip
+# mid-suite. Limiting behavior itself is covered by RateLimitingTests.
+app:
+  auth-throttle:
+    ip-limit: 1000000
+    max-failures: 1000000


### PR DESCRIPTION
Closes #16.

## What

- **Per-IP throttle** — `RateLimitFilter` (Bucket4j 8.14 + Caffeine): 10 POSTs / 15 min per IP on the public auth endpoints. 429 + `Retry-After`. Registered in the security chain ahead of `JwtAuthFilter`; deliberately not a `@Component` so it doesn't double-register in the servlet chain.
- **Per-email lockout** — `LoginAttemptService`: 5 failed logins / 15 min -> 15 min temp lock, logged (feeds #24 audit trail). Wired into all three login paths. Unknown emails tracked too and the 429 is identical either way, so lockout can't be used to enumerate accounts.
- `AccountLockedException` -> 429 with `Retry-After` via `GlobalExceptionHandler`. In `AuthController` the lock check sits outside the catch-all try so it isn't swallowed into a 500.
- Thresholds configurable under `app.auth-throttle` in `application.yml`.

## Acceptance criteria

- [x] Login/activation limited per IP and per username
- [x] 429 with Retry-After when limited
- [x] Repeated failures -> temp lockout, logged
- [x] Tests: lockout trigger, reset on success, unknown-email tracking, IP bucket 429 + refill, non-auth path skip

## Notes

- In-memory state on purpose (single node) — no Flyway migration, no schema change.
- `remoteAddr` used for keying; `X-Forwarded-For` ignored since it's client-spoofable and there's no trusted proxy.
