### PR TITLE
Renewal reminder emails (60/30/7 days) with ShedLock (#14)

### DIFF
--- a/healthcare/pom.xml
+++ b/healthcare/pom.xml
@@ -60,6 +60,16 @@
             <groupId>org.hibernate.orm</groupId>
             <artifactId>hibernate-envers</artifactId>
         </dependency>
+        <dependency>
+            <groupId>net.javacrumbs.shedlock</groupId>
+            <artifactId>shedlock-spring</artifactId>
+            <version>6.9.0</version>
+        </dependency>
+        <dependency>
+            <groupId>net.javacrumbs.shedlock</groupId>
+            <artifactId>shedlock-provider-jdbc-template</artifactId>
+            <version>6.9.0</version>
+        </dependency>
 
         <!-- Database -->
         <dependency>

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/correspondence/service/RenewalReminderService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/correspondence/service/RenewalReminderService.kt
@@ -1,0 +1,69 @@
+package com.lakshay.healthcare.correspondence.service
+
+import com.lakshay.healthcare.shared.notification.NotificationService
+import com.lakshay.healthcare.shared.repository.CitizenAppRegistrationRepository
+import com.lakshay.healthcare.shared.repository.DcCaseRepository
+import com.lakshay.healthcare.shared.repository.EligibilityDetailsRepository
+import com.lakshay.healthcare.shared.repository.NoticeRepository
+import net.javacrumbs.shedlock.spring.annotation.SchedulerLock
+import org.slf4j.LoggerFactory
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty
+import org.springframework.scheduling.annotation.Scheduled
+import org.springframework.stereotype.Service
+import java.time.LocalDate
+
+// Nudges citizens to renew at 60/30/7 days before their plan ends. Off in tests
+// (the cron never fires in a short-lived JVM anyway; the flag keeps the bean out too).
+@Service
+@ConditionalOnProperty(name = ["app.renewal-reminders.enabled"], havingValue = "true", matchIfMissing = true)
+class RenewalReminderService(
+    private val eligibilityRepository: EligibilityDetailsRepository,
+    private val dcCaseRepository: DcCaseRepository,
+    private val citizenRepository: CitizenAppRegistrationRepository,
+    private val noticeRepository: NoticeRepository,
+    private val notificationService: NotificationService
+) {
+    private val log = LoggerFactory.getLogger(RenewalReminderService::class.java)
+
+    companion object {
+        val MILESTONES = listOf(60L, 30L, 7L)
+
+        // which renewal milestone a plan-end date hits relative to today, or null. Pure — the test drives this.
+        fun dueMilestone(today: LocalDate, planEndDate: LocalDate?): Long? =
+            planEndDate?.let { end -> MILESTONES.firstOrNull { today.plusDays(it) == end } }
+    }
+
+    @Scheduled(cron = "0 0 3 * * *")
+    @SchedulerLock(name = "renewalReminders", lockAtLeastFor = "1m", lockAtMostFor = "15m")
+    fun sendRenewalReminders() {
+        val today = LocalDate.now()
+        var sent = 0
+        for (days in MILESTONES) {
+            val target = today.plusDays(days)
+            for (elig in eligibilityRepository.findByPlanStatusAndPlanEndDate("APPROVED", target)) {
+                if (remind(elig.caseNo, elig.planName, target, days)) sent++
+            }
+        }
+        log.info("Renewal reminders sent: {}", sent)
+    }
+
+    // dedup on a SENT notice, not mere existence — a prior FAILED send must retry.
+    // Email carries plan name + end date only; never SSN or bank details.
+    private fun remind(caseNo: Long, planName: String?, endDate: LocalDate, days: Long): Boolean {
+        val type = "RENEWAL_$days"
+        if (noticeRepository.existsByCaseNoAndNoticeTypeAndStatus(caseNo, type, "SENT")) return false
+        val email = dcCaseRepository.findByCaseNo(caseNo)
+            ?.let { citizenRepository.findByAppId(it.appId)?.email }
+        if (email == null) {
+            log.warn("No citizen email for case {}, renewal reminder skipped", caseNo)
+            return false
+        }
+        val notice = notificationService.notifyEmail(
+            caseNo = caseNo, recipient = email, noticeType = type,
+            subject = "Your ${planName ?: "plan"} renews soon - Case #$caseNo",
+            body = "Your ${planName ?: "plan"} coverage ends on $endDate ($days days away). " +
+                "Log in to your portal to renew before it lapses."
+        )
+        return notice?.status == "SENT"
+    }
+}

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/config/SchedulingConfig.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/config/SchedulingConfig.kt
@@ -1,0 +1,26 @@
+package com.lakshay.healthcare.shared.config
+
+import net.javacrumbs.shedlock.core.LockProvider
+import net.javacrumbs.shedlock.provider.jdbctemplate.JdbcTemplateLockProvider
+import net.javacrumbs.shedlock.spring.annotation.EnableSchedulerLock
+import org.springframework.context.annotation.Bean
+import org.springframework.context.annotation.Configuration
+import org.springframework.jdbc.core.JdbcTemplate
+import org.springframework.scheduling.annotation.EnableScheduling
+import javax.sql.DataSource
+
+// defaultLockAtMostFor is the safety net: if a node dies mid-job the lock frees after this.
+@Configuration
+@EnableScheduling
+@EnableSchedulerLock(defaultLockAtMostFor = "15m")
+class SchedulingConfig {
+
+    @Bean
+    fun lockProvider(dataSource: DataSource): LockProvider =
+        JdbcTemplateLockProvider(
+            JdbcTemplateLockProvider.Configuration.builder()
+                .withJdbcTemplate(JdbcTemplate(dataSource))
+                .usingDbTime() // lock timing off the DB clock, not each node's
+                .build()
+        )
+}

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/repository/EligibilityDetailsRepository.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/repository/EligibilityDetailsRepository.kt
@@ -9,6 +9,7 @@ import org.springframework.stereotype.Repository
 @Repository
 interface EligibilityDetailsRepository : JpaRepository<com.lakshay.healthcare.shared.entity.EligibilityDetails, Long> {
     fun findByCaseNo(caseNo: Long): com.lakshay.healthcare.shared.entity.EligibilityDetails?
+    fun findByPlanStatusAndPlanEndDate(planStatus: String, planEndDate: java.time.LocalDate): List<com.lakshay.healthcare.shared.entity.EligibilityDetails>
     fun findAllByPlanStatus(planStatus: String): List<com.lakshay.healthcare.shared.entity.EligibilityDetails>
     fun findByPlanStatus(planStatus: String, pageable: Pageable): Page<com.lakshay.healthcare.shared.entity.EligibilityDetails>
 }

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/repository/NoticeRepository.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/repository/NoticeRepository.kt
@@ -6,4 +6,5 @@ import org.springframework.data.jpa.repository.JpaRepository
 interface NoticeRepository : JpaRepository<Notice, Long> {
     fun findByRecipientOrderByCreatedAtDesc(recipient: String): List<Notice>
     fun findByCaseNo(caseNo: Long): List<Notice>
+    fun existsByCaseNoAndNoticeTypeAndStatus(caseNo: Long, noticeType: String, status: String): Boolean
 }

--- a/healthcare/src/main/resources/db/migration/V13__create_shedlock.sql
+++ b/healthcare/src/main/resources/db/migration/V13__create_shedlock.sql
@@ -1,0 +1,8 @@
+-- ShedLock's single lock row per scheduled task. JDBC-only (JdbcTemplateLockProvider),
+-- not a JPA entity, so ddl-auto: validate never looks at it.
+CREATE TABLE IF NOT EXISTS shedlock (
+    name VARCHAR(64) NOT NULL PRIMARY KEY,
+    lock_until TIMESTAMP(3) NOT NULL,
+    locked_at TIMESTAMP(3) NOT NULL,
+    locked_by VARCHAR(255) NOT NULL
+);

--- a/healthcare/src/test/kotlin/com/lakshay/healthcare/correspondence/service/RenewalReminderTests.kt
+++ b/healthcare/src/test/kotlin/com/lakshay/healthcare/correspondence/service/RenewalReminderTests.kt
@@ -1,0 +1,35 @@
+package com.lakshay.healthcare.correspondence.service
+
+import org.junit.jupiter.api.Test
+import java.time.LocalDate
+import kotlin.test.assertEquals
+import kotlin.test.assertNull
+
+class RenewalReminderTests {
+
+    private val today = LocalDate.of(2026, 1, 1)
+
+    @Test
+    fun `hits the 60 30 7 day marks`() {
+        assertEquals(60L, RenewalReminderService.dueMilestone(today, today.plusDays(60)))
+        assertEquals(30L, RenewalReminderService.dueMilestone(today, today.plusDays(30)))
+        assertEquals(7L, RenewalReminderService.dueMilestone(today, today.plusDays(7)))
+    }
+
+    @Test
+    fun `dates between the marks are not due`() {
+        assertNull(RenewalReminderService.dueMilestone(today, today.plusDays(45)))
+        assertNull(RenewalReminderService.dueMilestone(today, today.plusDays(15)))
+        assertNull(RenewalReminderService.dueMilestone(today, today.plusDays(1)))
+    }
+
+    @Test
+    fun `past end date is not due`() {
+        assertNull(RenewalReminderService.dueMilestone(today, today.minusDays(10)))
+    }
+
+    @Test
+    fun `null end date is not due`() {
+        assertNull(RenewalReminderService.dueMilestone(today, null))
+    }
+}

--- a/healthcare/src/test/resources/application-test.yml
+++ b/healthcare/src/test/resources/application-test.yml
@@ -39,3 +39,5 @@ app:
   auth-throttle:
     ip-limit: 1000000
     max-failures: 1000000
+  renewal-reminders:
+    enabled: false


### PR DESCRIPTION
Closes #14. Stacked on #13's branch (`issue-13-case-timeline`) — merge order: #16 → #19 → #12 → #13 → this. (Functionally independent of the others; stacked only because it was built in sequence. GitHub retargets to main as parents merge.)

## What

- **Daily scheduled job** (`RenewalReminderService`, 3am cron) emails citizens whose APPROVED plan ends in 60, 30, or 7 days.
- **ShedLock 6.9.0** (`shedlock-spring` + `shedlock-provider-jdbc-template`) — `@SchedulerLock` over a single JDBC lock table (V13) keeps the job single-fire if the app ever runs multi-instance. `JdbcTemplateLockProvider` with `usingDbTime()` so lock windows key off the DB clock, not each node's. `lockAtMostFor=15m` frees the lock if a node dies mid-run.
- **No duplicate reminders** — dedup on a `SENT` Notice per case+milestone (`noticeType` `RENEWAL_60/30/7`). A re-run or a missed-day catch-up won't double up, and a prior `FAILED` send still retries (dedup deliberately keys on `SENT`, not mere existence).
- Emails carry plan name + end date only — never SSN or bank details — and go through `NotificationService.notifyEmail`, leaving a Notice row like every other notice.
- **Milestone selection** is a pure companion fn (`dueMilestone(today, planEndDate)`) the test drives directly.
- Job bean is gated off in tests via `@ConditionalOnProperty` (`app.renewal-reminders.enabled=false` in the test profile) so the cron never registers in the suite.

## Acceptance criteria

- [x] Daily job finds cases at the 60/30/7-day marks and emails each
- [x] No duplicate reminders per case+milestone (SENT-notice guard)
- [x] `@SchedulerLock` guards the job; lock table in Flyway (V13)
- [x] Test covering milestone selection logic (`RenewalReminderTests` — all three marks, in-between/past/null dates)

## Notes

- ShedLock table is JDBC-only (not a JPA entity), so `ddl-auto: validate` doesn't touch it.
- Exact-date match on purpose: simple, and dedup makes re-runs safe. Worst case a one-day app outage skips that day's marks — acceptable for a reminder, not a determination.
- Single-node today; ShedLock is the forward-looking guard the AC asked for.
- Unit test green; full IT context boots with the scheduler config + V13.
