### PR TITLE
refactor: extract magic numbers to named constants

### DIFF
--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/benefit/config/BatchConfig.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/benefit/config/BatchConfig.kt
@@ -20,6 +20,11 @@ import org.springframework.transaction.PlatformTransactionManager
 @Configuration
 class BatchConfig {
 
+    companion object {
+        private const val PAGE_SIZE = 10
+        private const val CHUNK_SIZE = 10
+    }
+
     @Value("\${benefit.issuance.output-file:benefit_output.csv}")
     private lateinit var outputFile: String
 
@@ -29,7 +34,7 @@ class BatchConfig {
         reader.setName("benefitItemReader")
         reader.setEntityManagerFactory(entityManagerFactory)
         reader.setQueryString("select e from EligibilityDetails e where e.planStatus = 'APPROVED'")
-        reader.setPageSize(10)
+        reader.setPageSize(PAGE_SIZE)
         reader.afterPropertiesSet()
         return reader
     }
@@ -65,7 +70,7 @@ class BatchConfig {
         writer: FlatFileItemWriter<EligibilityDetails>
     ): org.springframework.batch.core.Step {
         return StepBuilder("benefitIssuanceStep", jobRepository)
-            .chunk<EligibilityDetails, EligibilityDetails>(10, transactionManager)
+            .chunk<EligibilityDetails, EligibilityDetails>(CHUNK_SIZE, transactionManager)
             .reader(reader)
             .processor(processor)
             .writer(writer)

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/benefit/processor/BenefitItemProcessor.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/benefit/processor/BenefitItemProcessor.kt
@@ -8,6 +8,10 @@ import org.springframework.stereotype.Component
 @Component
 class BenefitItemProcessor : ItemProcessor<com.lakshay.healthcare.shared.entity.EligibilityDetails, com.lakshay.healthcare.shared.entity.EligibilityDetails> {
 
+    companion object {
+        private const val ACCOUNT_NUMBER_MODULUS = 100000
+    }
+
     private val logger = LoggerFactory.getLogger(BenefitItemProcessor::class.java)
 
     override fun process(item: com.lakshay.healthcare.shared.entity.EligibilityDetails): com.lakshay.healthcare.shared.entity.EligibilityDetails {
@@ -20,6 +24,6 @@ class BenefitItemProcessor : ItemProcessor<com.lakshay.healthcare.shared.entity.
     }
 
     private fun generateAccountNumber(caseNo: Long): String {
-        return "ISH${caseNo}${System.currentTimeMillis() % 100000}"
+        return "ISH${caseNo}${System.currentTimeMillis() % ACCOUNT_NUMBER_MODULUS}"
     }
 }

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/correspondence/service/CorrespondenceService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/correspondence/service/CorrespondenceService.kt
@@ -32,6 +32,14 @@ class CorrespondenceService(
     private val notificationService: NotificationService
 ) {
 
+    companion object {
+        private const val TITLE_FONT_SIZE = 20f
+        private const val TABLE_COLUMN_COUNT = 6
+        private const val TABLE_WIDTH_PCT = 90f
+        private const val TABLE_SPACING_BEFORE = 10f
+        private const val HEADER_PADDING = 5f
+    }
+
     private val logger = LoggerFactory.getLogger(CorrespondenceService::class.java)
 
     fun processTriggers(): List<TriggerResponse> {
@@ -108,22 +116,22 @@ class CorrespondenceService(
         PdfWriter.getInstance(document, outputStream)
         document.open()
 
-        val titleFont = FontFactory.getFont(FontFactory.TIMES_BOLD, 20f)
+        val titleFont = FontFactory.getFont(FontFactory.TIMES_BOLD, TITLE_FONT_SIZE)
         val title = Paragraph("Plan Approval/Denial Communication", titleFont)
         title.alignment = Paragraph.ALIGN_CENTER
         document.add(title)
         document.add(Paragraph(" "))
 
-        val table = PdfPTable(6)
-        table.widthPercentage = 90f
-        table.setSpacingBefore(10f)
+        val table = PdfPTable(TABLE_COLUMN_COUNT)
+        table.widthPercentage = TABLE_WIDTH_PCT
+        table.setSpacingBefore(TABLE_SPACING_BEFORE)
 
         val headerFont = FontFactory.getFont(FontFactory.HELVETICA_BOLD)
 
         fun addHeaderCell(text: String) {
             val cell = PdfPCell(Phrase(text, headerFont))
             cell.backgroundColor = Color.LIGHT_GRAY
-            cell.setPadding(5f)
+            cell.setPadding(HEADER_PADDING)
             table.addCell(cell)
         }
 

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/eligibility/service/EligibilityDeterminationService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/eligibility/service/EligibilityDeterminationService.kt
@@ -46,6 +46,16 @@ class EligibilityDeterminationService(
     private val statusEmailService: StatusEmailService
 ) {
 
+    companion object {
+        private const val SNAP_DEFAULT_INCOME_LIMIT = 300.0
+        private const val CCAP_MAX_CHILD_AGE = 16
+        private const val CCAP_DEFAULT_INCOME_LIMIT = 300.0
+        private const val MEDCARE_MIN_AGE = 65
+        private const val MEDAID_DEFAULT_INCOME_LIMIT = 300.0
+        private const val QHP_MIN_AGE = 25
+        private const val FALLBACK_INCOME_LIMIT = 10000
+    }
+
     fun determineEligibility(caseNo: Long): EligibilityResponse {
         val dcCase = dcCaseRepository.findByCaseNo(caseNo)
             ?: throw ResourceNotFoundException("Case not found: $caseNo")
@@ -166,7 +176,7 @@ class EligibilityDeterminationService(
 
         return when (planName.uppercase()) {
             "SNAP" -> {
-                if (empIncome < (rule?.incomeLimit ?: 300.0)) {
+                if (empIncome < (rule?.incomeLimit ?: SNAP_DEFAULT_INCOME_LIMIT)) {
                     EligibilityResponse(
                         planStatus = "APPROVED",
                         planName = planName,
@@ -187,9 +197,9 @@ class EligibilityDeterminationService(
             "CCAP" -> {
                 val hasEligibleKids = children.isNotEmpty()
                 val allKidsUnderLimit = children.all { child ->
-                    child.childDOB?.let { Period.between(it, LocalDate.now()).years <= 16 } ?: true
+                    child.childDOB?.let { Period.between(it, LocalDate.now()).years <= CCAP_MAX_CHILD_AGE } ?: true
                 }
-                if (empIncome < (rule?.incomeLimit ?: 300.0) && hasEligibleKids && allKidsUnderLimit) {
+                if (empIncome < (rule?.incomeLimit ?: CCAP_DEFAULT_INCOME_LIMIT) && hasEligibleKids && allKidsUnderLimit) {
                     EligibilityResponse(
                         planStatus = "APPROVED",
                         planName = planName,
@@ -208,7 +218,7 @@ class EligibilityDeterminationService(
                 }
             }
             "MEDCARE" -> {
-                if (citizenAge >= 65) {
+                if (citizenAge >= MEDCARE_MIN_AGE) {
                     EligibilityResponse(
                         planStatus = "APPROVED",
                         planName = planName,
@@ -227,7 +237,7 @@ class EligibilityDeterminationService(
                 }
             }
             "MEDAID" -> {
-                if (empIncome < (rule?.incomeLimit ?: 300.0) && propertyIncome == 0.0) {
+                if (empIncome < (rule?.incomeLimit ?: MEDAID_DEFAULT_INCOME_LIMIT) && propertyIncome == 0.0) {
                     EligibilityResponse(
                         planStatus = "APPROVED",
                         planName = planName,
@@ -266,7 +276,7 @@ class EligibilityDeterminationService(
                 }
             }
             "QHP" -> {
-                if (citizenAge >= 25) {
+                if (citizenAge >= QHP_MIN_AGE) {
                     EligibilityResponse(
                         planStatus = "APPROVED",
                         planName = planName,
@@ -286,7 +296,7 @@ class EligibilityDeterminationService(
             }
             else -> {
                 val totalIncome = empIncome + propertyIncome
-                if (totalIncome < 10000) {
+                if (totalIncome < FALLBACK_INCOME_LIMIT) {
                     EligibilityResponse(
                         planStatus = "APPROVED",
                         planName = planName,

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/report/service/GovernmentReportService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/report/service/GovernmentReportService.kt
@@ -23,6 +23,11 @@ class GovernmentReportService(
     private val planRepository: PlanRepository
 ) {
 
+    companion object {
+        private const val SEPARATOR_LENGTH = 50
+        private const val PERCENTAGE_MULTIPLIER = 100
+    }
+
     fun generateReport(request: ReportRequest): ReportResponse {
         val totalApplications = citizenRepository.count()
         val approvedCount = eligibilityRepository.findAllByPlanStatus("APPROVED").size
@@ -109,13 +114,13 @@ class GovernmentReportService(
             appendLine("Type: ${request.reportType}")
             appendLine("Period: ${request.periodCovered ?: "Current"}")
             appendLine("Generated: ${LocalDate.now()}")
-            appendLine("=" .repeat(50))
+            appendLine("=" .repeat(SEPARATOR_LENGTH))
             appendLine()
             appendLine("APPLICATION STATISTICS")
             appendLine("Total Applications: $totalApplications")
             appendLine("Approved: $approvedCount")
             appendLine("Denied: $deniedCount")
-            appendLine("Approval Rate: ${if (totalApplications > 0) "%.1f".format(approvedCount.toDouble() / totalApplications * 100) else "0"}%")
+            appendLine("Approval Rate: ${if (totalApplications > 0) "%.1f".format(approvedCount.toDouble() / totalApplications * PERCENTAGE_MULTIPLIER) else "0"}%")
             appendLine()
             appendLine("PLAN STATISTICS")
             appendLine("Total Plans: $totalPlans")
@@ -123,7 +128,7 @@ class GovernmentReportService(
             appendLine("BENEFIT STATISTICS")
             appendLine("Total Eligible Citizens: $approvedCount")
             appendLine("Total Denied: $deniedCount")
-            appendLine("=" .repeat(50))
+            appendLine("=" .repeat(SEPARATOR_LENGTH))
             appendLine("End of Report")
         }
     }

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/security/JwtAuthFilter.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/security/JwtAuthFilter.kt
@@ -22,6 +22,10 @@ class JwtAuthFilter(
     private val jwtUtil: JwtUtil
 ) : OncePerRequestFilter() {
 
+    companion object {
+        private const val BEARER_PREFIX_LENGTH = 7
+    }
+
     override fun doFilterInternal(
         request: HttpServletRequest,
         response: HttpServletResponse,
@@ -29,7 +33,7 @@ class JwtAuthFilter(
     ) {
         val authHeader = request.getHeader("Authorization")
         if (authHeader != null && authHeader.startsWith("Bearer ")) {
-            authenticate(authHeader.substring(7))
+            authenticate(authHeader.substring(BEARER_PREFIX_LENGTH))
         }
         filterChain.doFilter(request, response)
     }

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/security/LoginAttemptService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/security/LoginAttemptService.kt
@@ -15,6 +15,12 @@ class LoginAttemptService(
     @Value("\${app.auth-throttle.max-failures:5}") private val maxFailures: Int,
     @Value("\${app.auth-throttle.lockout-minutes:15}") private val lockoutMinutes: Long
 ) {
+
+    companion object {
+        private const val CACHE_MAX_SIZE = 100_000L
+        private const val SECONDS_PER_MINUTE = 60
+    }
+
     private val log = LoggerFactory.getLogger(LoginAttemptService::class.java)
 
     private class Attempts {
@@ -25,11 +31,11 @@ class LoginAttemptService(
 
     private val attempts = Caffeine.newBuilder()
         .expireAfterWrite(Duration.ofMinutes(lockoutMinutes))
-        .maximumSize(100_000)
+        .maximumSize(CACHE_MAX_SIZE)
         .build<String, Attempts>()
 
     // static value, not remaining time — don't leak lock age per account
-    fun lockoutSeconds(): Long = lockoutMinutes * 60
+    fun lockoutSeconds(): Long = lockoutMinutes * SECONDS_PER_MINUTE
 
     fun isLocked(email: String): Boolean {
         val until = attempts.getIfPresent(key(email))?.lockedUntil ?: return false

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/security/RateLimitFilter.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/security/RateLimitFilter.kt
@@ -31,11 +31,12 @@ class RateLimitFilter(
             "/worker-api/login",
             "/worker-api/activate"
         )
+        private const val CACHE_MAX_SIZE = 100_000L
     }
 
     private val buckets: LoadingCache<String, Bucket> = Caffeine.newBuilder()
         .expireAfterAccess(window.multipliedBy(2))
-        .maximumSize(100_000) // spoofed-IP flood shouldn't OOM us
+        .maximumSize(CACHE_MAX_SIZE) // spoofed-IP flood shouldn't OOM us
         .build { _ ->
             Bucket.builder()
                 .addLimit(Bandwidth.classic(limit, Refill.intervally(limit, window)))

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/security/RefreshTokenService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/security/RefreshTokenService.kt
@@ -27,6 +27,12 @@ class RefreshTokenService(
     private val userRepository: UserMasterRepository,
     @Value("\${jwt.refresh-expiration}") private val refreshExpirationMs: Long
 ) {
+
+    companion object {
+        private const val TOKEN_BYTE_LENGTH = 32
+        private const val MS_PER_SECOND = 1000
+    }
+
     private val log = LoggerFactory.getLogger(RefreshTokenService::class.java)
     private val random = SecureRandom()
 
@@ -76,7 +82,7 @@ class RefreshTokenService(
     }
 
     private fun newToken(email: String, role: String, familyId: String): String {
-        val bytes = ByteArray(32)
+        val bytes = ByteArray(TOKEN_BYTE_LENGTH)
         random.nextBytes(bytes)
         val raw = Base64.getUrlEncoder().withoutPadding().encodeToString(bytes)
         refreshTokenRepository.save(
@@ -85,7 +91,7 @@ class RefreshTokenService(
                 familyId = familyId,
                 userEmail = email,
                 role = role,
-                expiresAt = LocalDateTime.now().plusSeconds(refreshExpirationMs / 1000)
+                expiresAt = LocalDateTime.now().plusSeconds(refreshExpirationMs / MS_PER_SECOND)
             )
         )
         return raw

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/util/MaskingUtils.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/util/MaskingUtils.kt
@@ -1,5 +1,7 @@
 package com.lakshay.healthcare.shared.util
 
-// ssn stored as Long, leading zeros lost — pad back to 9 before slicing
+private const val SSN_LENGTH = 9
+private const val MASK_VISIBLE_DIGITS = 4
+
 fun maskSsnLast4(ssn: Long?): String =
-    ssn?.toString()?.padStart(9, '0')?.takeLast(4)?.let { "***-**-$it" } ?: ""
+    ssn?.toString()?.padStart(SSN_LENGTH, '0')?.takeLast(MASK_VISIBLE_DIGITS)?.let { "***-**-$it" } ?: ""

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/ssa/service/SsnValidationService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/ssa/service/SsnValidationService.kt
@@ -6,19 +6,27 @@ import org.springframework.stereotype.Service
 @Service
 class SsnValidationService {
 
+    companion object {
+        private const val SSN_LENGTH = 9
+        private const val STATE_CODE_DIVISOR = 100
+        private const val STATE_CODE_TEXAS = 3
+        private const val STATE_CODE_CALIFORNIA = 4
+        private const val STATE_CODE_FLORIDA = 5
+    }
+
     fun validateSsn(ssn: Long): String {
         val ssnStr = ssn.toString()
-        if (ssnStr.length != 9) {
+        if (ssnStr.length != SSN_LENGTH) {
             throw InvalidSsnException("Invalid SSN: $ssn - SSN must be exactly 9 digits")
         }
 
-        val stateCode = (ssn % 100).toInt()
+        val stateCode = (ssn % STATE_CODE_DIVISOR).toInt()
         return when (stateCode) {
             1 -> "Washington DC"
             2 -> "Ohio"
-            3 -> "Texas"
-            4 -> "California"
-            5 -> "Florida"
+            STATE_CODE_TEXAS -> "Texas"
+            STATE_CODE_CALIFORNIA -> "California"
+            STATE_CODE_FLORIDA -> "Florida"
             else -> throw InvalidSsnException("Invalid SSN: $ssn - No state mapped for code $stateCode")
         }
     }

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/user/service/UserMgmtService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/user/service/UserMgmtService.kt
@@ -36,6 +36,10 @@ class UserMgmtService(
     private val refreshTokenService: RefreshTokenService
 ) {
 
+    companion object {
+        private const val PASSWORD_LENGTH = 6
+    }
+
     fun registerUser(request: RegisterRequest): RegistrationResult = register(request, "USER")
 
     fun registerCitizen(request: RegisterRequest): RegistrationResult = register(request, "CITIZEN")
@@ -45,7 +49,7 @@ class UserMgmtService(
             throw DuplicateResourceException("User with email ${request.email} already exists")
         }
 
-        val tempPwd = generateRandomPassword(6)
+        val tempPwd = generateRandomPassword(PASSWORD_LENGTH)
 
         val user = UserMaster(
             name = request.name,

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/user/service/WorkerMgmtService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/user/service/WorkerMgmtService.kt
@@ -36,12 +36,16 @@ class WorkerMgmtService(
     private val refreshTokenService: RefreshTokenService
 ) {
 
+    companion object {
+        private const val PASSWORD_LENGTH = 6
+    }
+
     fun registerWorker(request: RegisterRequest): WorkerRegistrationResult {
         if (workerRepository.findByEmail(request.email) != null) {
             throw DuplicateResourceException("Worker with email ${request.email} already exists")
         }
 
-        val tempPwd = generateRandomPassword(6)
+        val tempPwd = generateRandomPassword(PASSWORD_LENGTH)
 
         val worker = WorkerMaster(
             name = request.name,


### PR DESCRIPTION
detekt: MagicNumber (33) across services/security/util.

Every literal moved to a named const with the **exact same value** — verified by diff, behavior unchanged. Domain thresholds read as `SNAP_DEFAULT_INCOME_LIMIT`/`MEDCARE_MIN_AGE`/etc; security ones as `TOKEN_BYTE_LENGTH`/`BEARER_PREFIX_LENGTH`/`CACHE_MAX_SIZE`.

`CACHE_MAX_SIZE` is `100_000L` — Caffeine.maximumSize wants a long, and a typed const doesn't adapt like a bare literal did.

Clears 33 findings (199 → 118 cumulative). Compiles clean. Stacked on #37.