### PR TITLE
refactor(admin): single validation exit in createAdmin

### DIFF
--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/admin/controller/AdminController.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/admin/controller/AdminController.kt
@@ -86,22 +86,26 @@ class AdminUserController(
 
     @PostMapping("/create")
     fun createAdmin(@RequestBody request: Map<String, String>): ResponseEntity<Map<String, Any>> {
-        val email = request["email"] ?: return ResponseEntity.badRequest()
-            .body(mapOf("error" to "Email is required"))
-        val name = request["name"] ?: return ResponseEntity.badRequest()
-            .body(mapOf("error" to "Name is required"))
-        val password = request["password"] ?: return ResponseEntity.badRequest()
-            .body(mapOf("error" to "Password is required"))
+        val email = request["email"]
+        val name = request["name"]
+        val password = request["password"]
 
-        if (adminRepository.findByEmail(email) != null) {
-            return ResponseEntity.status(HttpStatus.CONFLICT)
-                .body(mapOf("error" to "Admin with this email already exists"))
+        // single exit for all validation — detekt caps returns at 2
+        val error = when {
+            email == null -> HttpStatus.BAD_REQUEST to "Email is required"
+            name == null -> HttpStatus.BAD_REQUEST to "Name is required"
+            password == null -> HttpStatus.BAD_REQUEST to "Password is required"
+            adminRepository.findByEmail(email) != null -> HttpStatus.CONFLICT to "Admin with this email already exists"
+            else -> null
+        }
+        if (error != null) {
+            return ResponseEntity.status(error.first).body(mapOf("error" to error.second))
         }
 
         val admin = AdminMaster(
-            name = name,
-            email = email,
-            password = passwordEncoder.encode(password),
+            name = name!!,
+            email = email!!,
+            password = passwordEncoder.encode(password!!),
             role = "ADMIN",
             activeSw = "Y"
         )


### PR DESCRIPTION
Module: **admin**. detekt ReturnCount — createAdmin had 5 returns; folded validation into one `when` (single error return + success = 2). Same statuses/messages/order.

Verified: AdminManagementIT 10/10 green (create, dup 409, missing-field 400).

Closes #41. Based on #38.