### PR TITLE
refactor(casework): wraps + justified suppressions

### DIFF
--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/casework/controller/CaseworkController.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/casework/controller/CaseworkController.kt
@@ -41,7 +41,10 @@ class CaseworkController(
         ResponseEntity.ok(caseworkService.queue(status))
 
     @PutMapping("/cases/{caseNo}/assignment")
-    fun assign(@PathVariable caseNo: Long, @RequestBody request: AssignmentRequest): ResponseEntity<AssignmentResponse> =
+    fun assign(
+        @PathVariable caseNo: Long,
+        @RequestBody request: AssignmentRequest
+    ): ResponseEntity<AssignmentResponse> =
         ResponseEntity.ok(caseworkService.assign(caseNo, request))
 
     @GetMapping("/cases/{caseNo}/assignment")
@@ -57,6 +60,9 @@ class CaseworkController(
         ResponseEntity.ok(caseworkService.listDocuments(caseNo))
 
     @PostMapping("/documents/{docId}/review")
-    fun review(@PathVariable docId: Long, @RequestBody request: DocumentReviewRequest): ResponseEntity<DocumentReviewResponse> =
+    fun review(
+        @PathVariable docId: Long,
+        @RequestBody request: DocumentReviewRequest
+    ): ResponseEntity<DocumentReviewResponse> =
         ResponseEntity.ok(caseworkService.reviewDocument(docId, request))
 }

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/casework/service/CaseworkService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/casework/service/CaseworkService.kt
@@ -32,6 +32,8 @@ import org.springframework.transaction.annotation.Transactional
 import java.time.LocalDateTime
 
 @Service
+// LongParameterList: Spring constructor injection — each dependency is a distinct bean
+@Suppress("LongParameterList")
 class CaseworkService(
     private val caseNoteRepository: CaseNoteRepository,
     private val dcCaseRepository: DcCaseRepository,
@@ -49,6 +51,9 @@ class CaseworkService(
     // Worker requests info from the citizen. The recipient is derived from the case (never a request
     // param), the message is rejected if it contains an SSN, and notificationSent reports whether the
     // portal notice actually went out (notifyPortal swallows its own failures).
+    // ThrowsCount: four distinct client errors (case 404, blank-msg 400, SSN 400, citizen 404).
+    // Each has its own type/message; folding would blur them.
+    @Suppress("ThrowsCount")
     fun requestInfo(caseNo: Long, request: RfiRequest): RfiResponse {
         val case = dcCaseRepository.findByCaseNo(caseNo)
             ?: throw ResourceNotFoundException("Case not found: $caseNo")
@@ -70,19 +75,27 @@ class CaseworkService(
 
     fun listDocuments(caseNo: Long): List<DocumentSummaryResponse> =
         documentRepository.findByCaseNo(caseNo).map {
-            DocumentSummaryResponse(it.docId, it.docType, it.fileName, it.contentType, it.status, it.createdAt.toString())
+            DocumentSummaryResponse(
+                it.docId, it.docType, it.fileName,
+                it.contentType, it.status, it.createdAt.toString()
+            )
         }
 
     @Transactional
     fun reviewDocument(docId: Long, request: DocumentReviewRequest): DocumentReviewResponse {
         val decision = request.decision.uppercase()
-        if (decision !in setOf("REVIEWED", "REJECTED")) throw ValidationException("decision must be REVIEWED or REJECTED")
+        if (decision !in setOf("REVIEWED", "REJECTED")) {
+            throw ValidationException("decision must be REVIEWED or REJECTED")
+        }
         if (!documentRepository.existsById(docId)) throw ResourceNotFoundException("Document not found: $docId")
         documentRepository.updateStatus(docId, decision)
         auditService.record("DOCUMENT_REVIEWED", "Document", docId.toString(), "decision=$decision")
         return DocumentReviewResponse(docId, decision)
     }
 
+    // ThrowsCount + SwallowedException: 404 + validation guards, plus a deliberate translation of
+    // DataIntegrityViolationException to DuplicateResourceException (which carries no cause slot).
+    @Suppress("ThrowsCount", "SwallowedException")
     fun assign(caseNo: Long, request: AssignmentRequest): AssignmentResponse {
         dcCaseRepository.findByCaseNo(caseNo)
             ?: throw ResourceNotFoundException("Case not found: $caseNo")
@@ -92,7 +105,9 @@ class CaseworkService(
         }
         val assignedBy = SecurityContextHolder.getContext().authentication?.name ?: "SYSTEM"
         val existing = caseAssignmentRepository.findByCaseNo(caseNo)
-        val toSave = existing?.copy(assignedTo = request.assignedTo, assignedBy = assignedBy, assignedAt = LocalDateTime.now())
+        val toSave = existing?.copy(
+            assignedTo = request.assignedTo, assignedBy = assignedBy, assignedAt = LocalDateTime.now()
+        )
             ?: CaseAssignment(caseNo = caseNo, assignedTo = request.assignedTo, assignedBy = assignedBy)
         val saved = try {
             caseAssignmentRepository.save(toSave)


### PR DESCRIPTION
Module: **casework**. Clears 9 findings (5 MaxLineLength, LongParameterList, 2 ThrowsCount, SwallowedException).

- 5 long lines wrapped.
- `@Suppress("LongParameterList")` — Spring DI ctor (9 beans).
- `@Suppress("ThrowsCount")` on requestInfo (404 + blank-msg 400 + SSN 400 + citizen 404) and assign — distinct types/messages, folding would blur them.
- `@Suppress("SwallowedException")` on assign's catch — deliberate translation of DataIntegrityViolationException -> DuplicateResourceException (no cause slot on that exception).

**Note:** several suppressions here — the rules fight legitimate multi-error validation / exception translation. Flagging for review; happy to instead add a cause slot to DuplicateResourceException (shared change) or restructure if you prefer.

No behavior change, compiles. Closes #45. Based on #38.