### PR TITLE
refactor(correspondence): error() idiom + remind restructure

### DIFF
--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/correspondence/service/CorrespondenceService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/correspondence/service/CorrespondenceService.kt
@@ -42,6 +42,9 @@ class CorrespondenceService(
 
     private val logger = LoggerFactory.getLogger(CorrespondenceService::class.java)
 
+    // TooGenericExceptionCaught: per-trigger resilience — one bad trigger is logged, marked FAILED,
+    // and the loop continues. The broad catch is the point.
+    @Suppress("TooGenericExceptionCaught")
     fun processTriggers(): List<TriggerResponse> {
         val pendingTriggers = coTriggerRepository.findByTriggerStatus("PENDING")
         val responses = mutableListOf<TriggerResponse>()
@@ -70,17 +73,19 @@ class CorrespondenceService(
         logger.info("Processing trigger for case number: {}", trigger.caseNo)
 
         val eligibility = eligibilityRepository.findByCaseNo(trigger.caseNo)
-            ?: throw IllegalStateException("No eligibility details found for case ${trigger.caseNo}")
+            ?: error("No eligibility details found for case ${trigger.caseNo}")
 
         val dcCase = dcCaseRepository.findByCaseNo(trigger.caseNo)
-            ?: throw IllegalStateException("No case found for case number ${trigger.caseNo}")
+            ?: error("No case found for case number ${trigger.caseNo}")
 
         val citizen = citizenRepository.findByAppId(dcCase.appId)
-            ?: throw IllegalStateException("No citizen found for appId ${dcCase.appId}")
+            ?: error("No citizen found for appId ${dcCase.appId}")
 
         val pdfBytes = generateBenefitPdf(eligibility)
 
-        val body = "Hello ${citizen.fullName},<br><br>This email contains complete details about your plan approval or denial.<br><br>Please see the attached PDF for details."
+        val body = "Hello ${citizen.fullName},<br><br>" +
+            "This email contains complete details about your plan approval or denial.<br><br>" +
+            "Please see the attached PDF for details."
         val emailSent = emailUtils.sendEmailWithAttachment(
             subject = "Plan Approval/Denial Notification - Case #${trigger.caseNo}",
             body = body,
@@ -89,7 +94,7 @@ class CorrespondenceService(
             attachmentData = pdfBytes
         )
         if (!emailSent) {
-            throw IllegalStateException("Email delivery failed for case ${trigger.caseNo}")
+            error("Email delivery failed for case ${trigger.caseNo}")
         }
 
         val updatedTrigger = trigger.copy(

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/correspondence/service/RenewalReminderService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/correspondence/service/RenewalReminderService.kt
@@ -54,16 +54,20 @@ class RenewalReminderService(
         if (noticeRepository.existsByCaseNoAndNoticeTypeAndStatus(caseNo, type, "SENT")) return false
         val email = dcCaseRepository.findByCaseNo(caseNo)
             ?.let { citizenRepository.findByAppId(it.appId)?.email }
-        if (email == null) {
-            log.warn("No citizen email for case {}, renewal reminder skipped", caseNo)
-            return false
+        return when {
+            email == null -> {
+                log.warn("No citizen email for case {}, renewal reminder skipped", caseNo)
+                false
+            }
+            else -> {
+                val notice = notificationService.notifyEmail(
+                    caseNo = caseNo, recipient = email, noticeType = type,
+                    subject = "Your ${planName ?: "plan"} renews soon - Case #$caseNo",
+                    body = "Your ${planName ?: "plan"} coverage ends on $endDate ($days days away). " +
+                        "Log in to your portal to renew before it lapses."
+                )
+                notice?.status == "SENT"
+            }
         }
-        val notice = notificationService.notifyEmail(
-            caseNo = caseNo, recipient = email, noticeType = type,
-            subject = "Your ${planName ?: "plan"} renews soon - Case #$caseNo",
-            body = "Your ${planName ?: "plan"} coverage ends on $endDate ($days days away). " +
-                "Log in to your portal to renew before it lapses."
-        )
-        return notice?.status == "SENT"
     }
 }


### PR DESCRIPTION
Module: **correspondence**. Clears 8 findings (4 UseCheckOrError, ThrowsCount, ReturnCount, MaxLineLength, TooGenericExceptionCaught).

- `throw IllegalStateException` -> `error()` (same exception) — fixes UseCheckOrError x4 **and** the ThrowsCount on processTrigger.
- Notification body wrapped via string concat.
- `RenewalReminderService.remind`: 3 returns -> 2 via `when`, same logic.
- `@Suppress("TooGenericExceptionCaught")` on processTriggers — per-trigger resilience (log + mark FAILED + continue).

Verified: GoldenLifecycleIT 3/3 green. Closes #46. Based on #38.