### PR TITLE
refactor(shared): catch-all suppressions + wraps + FQN shortening

### DIFF
--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/audit/AuditService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/audit/AuditService.kt
@@ -14,6 +14,8 @@ class AuditService(private val auditRepository: AuditEventRepository) {
 
     private val log = LoggerFactory.getLogger(AuditService::class.java)
 
+    // TooGenericExceptionCaught: audit writes must never break the caller — log and swallow.
+    @Suppress("TooGenericExceptionCaught")
     fun record(action: String, entityType: String? = null, entityId: String? = null, detail: String? = null) {
         try {
             val auth = SecurityContextHolder.getContext().authentication

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/config/WebConfig.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/config/WebConfig.kt
@@ -22,10 +22,14 @@ class WebConfig(
             .ifEmpty { listOf("*") }
 
         if (origins.contains("*")) {
-            log.warn("CORS allowed-origins is '*' (all origins allowed). Set app.cors.allowed-origins to a specific list in production.")
+            log.warn(
+                "CORS allowed-origins is '*' (all origins allowed). " +
+                    "Set app.cors.allowed-origins to a specific list in production."
+            )
         }
 
         return object : WebMvcConfigurer {
+            @Suppress("SpreadOperator") // allowedOrigins is vararg — the configured list must be spread
             override fun addCorsMappings(registry: CorsRegistry) {
                 registry.addMapping("/**")
                     .allowedOrigins(*origins.toTypedArray())

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/notification/NotificationService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/notification/NotificationService.kt
@@ -18,6 +18,8 @@ class NotificationService(
     private val log = LoggerFactory.getLogger(NotificationService::class.java)
 
     // Drop a notice in the recipient's portal inbox. The row itself is the delivery, so it's SENT.
+    // TooGenericExceptionCaught: notification failures are logged, never propagated to the caller.
+    @Suppress("TooGenericExceptionCaught")
     fun notifyPortal(caseNo: Long?, recipient: String, noticeType: String, subject: String, body: String): Notice? =
         try {
             noticeRepository.save(
@@ -33,6 +35,8 @@ class NotificationService(
         }
 
     // Email a notice and record whether it went out.
+    // TooGenericExceptionCaught: notification failures are logged, never propagated to the caller.
+    @Suppress("TooGenericExceptionCaught")
     fun notifyEmail(caseNo: Long?, recipient: String, noticeType: String, subject: String, body: String): Notice? =
         try {
             val saved = noticeRepository.save(

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/notification/StatusEmailService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/notification/StatusEmailService.kt
@@ -9,6 +9,8 @@ import org.thymeleaf.spring6.SpringTemplateEngine
 // send leaves a Notice row. Model is a whitelist — no SSN, no entities, ever.
 // Nothing here throws: a mail hiccup must not block the state change that caused it.
 @Service
+// LongParameterList: Spring constructor injection — each dependency is a distinct bean
+@Suppress("LongParameterList")
 class StatusEmailService(
     private val templateEngine: SpringTemplateEngine,
     private val notificationService: NotificationService
@@ -50,6 +52,8 @@ class StatusEmailService(
         )
     }
 
+    // TooGenericExceptionCaught: a failed status email must not break the state change that triggered it.
+    @Suppress("TooGenericExceptionCaught")
     private fun send(caseNo: Long, recipient: String, type: String, subject: String, model: Map<String, Any?>) {
         try {
             val html = templateEngine.process("mail/status-change", Context().apply { setVariables(model) })

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/repository/CitizenAppRegistrationRepository.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/repository/CitizenAppRegistrationRepository.kt
@@ -5,8 +5,8 @@ import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface CitizenAppRegistrationRepository : JpaRepository<com.lakshay.healthcare.shared.entity.CitizenAppRegistration, Long> {
-    fun findBySsn(ssn: Long): com.lakshay.healthcare.shared.entity.CitizenAppRegistration?
-    fun findByAppId(appId: Long): com.lakshay.healthcare.shared.entity.CitizenAppRegistration?
-    fun findByEmail(email: String): List<com.lakshay.healthcare.shared.entity.CitizenAppRegistration>
+interface CitizenAppRegistrationRepository : JpaRepository<CitizenAppRegistration, Long> {
+    fun findBySsn(ssn: Long): CitizenAppRegistration?
+    fun findByAppId(appId: Long): CitizenAppRegistration?
+    fun findByEmail(email: String): List<CitizenAppRegistration>
 }

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/repository/EligibilityDetailsRepository.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/repository/EligibilityDetailsRepository.kt
@@ -1,15 +1,16 @@
 ﻿package com.lakshay.healthcare.shared.repository
 
 import com.lakshay.healthcare.shared.entity.EligibilityDetails
+import java.time.LocalDate
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
 
 @Repository
-interface EligibilityDetailsRepository : JpaRepository<com.lakshay.healthcare.shared.entity.EligibilityDetails, Long> {
-    fun findByCaseNo(caseNo: Long): com.lakshay.healthcare.shared.entity.EligibilityDetails?
-    fun findByPlanStatusAndPlanEndDate(planStatus: String, planEndDate: java.time.LocalDate): List<com.lakshay.healthcare.shared.entity.EligibilityDetails>
-    fun findAllByPlanStatus(planStatus: String): List<com.lakshay.healthcare.shared.entity.EligibilityDetails>
-    fun findByPlanStatus(planStatus: String, pageable: Pageable): Page<com.lakshay.healthcare.shared.entity.EligibilityDetails>
+interface EligibilityDetailsRepository : JpaRepository<EligibilityDetails, Long> {
+    fun findByCaseNo(caseNo: Long): EligibilityDetails?
+    fun findByPlanStatusAndPlanEndDate(planStatus: String, planEndDate: LocalDate): List<EligibilityDetails>
+    fun findAllByPlanStatus(planStatus: String): List<EligibilityDetails>
+    fun findByPlanStatus(planStatus: String, pageable: Pageable): Page<EligibilityDetails>
 }

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/repository/RefreshTokenRepository.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/repository/RefreshTokenRepository.kt
@@ -14,7 +14,10 @@ interface RefreshTokenRepository : JpaRepository<RefreshToken, Long> {
     // atomic claim — rowcount 0 means the token was already spent/revoked/missing,
     // so two concurrent refreshes can't both win
     @Modifying(clearAutomatically = true)
-    @Query("update RefreshToken t set t.usedSw = 'Y' where t.tokenHash = :hash and t.usedSw = 'N' and t.revokedSw = 'N'")
+    @Query(
+        "update RefreshToken t set t.usedSw = 'Y' " +
+            "where t.tokenHash = :hash and t.usedSw = 'N' and t.revokedSw = 'N'"
+    )
     fun claim(@Param("hash") hash: String): Int
 
     @Modifying(clearAutomatically = true)

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/security/JwtAuthFilter.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/security/JwtAuthFilter.kt
@@ -41,6 +41,9 @@ class JwtAuthFilter(
     // Valid token -> set auth. Anything thrown (malformed/expired) is swallowed so the request
     // falls through unauthenticated and the authz layer 401s it. Never a 500 — JJWT errors aren't
     // AuthenticationExceptions.
+    // Broad catch on purpose: any bad/expired/malformed token just leaves the request
+    // unauthenticated for the authz layer to 401. JJWT errors aren't AuthenticationExceptions.
+    @Suppress("TooGenericExceptionCaught", "SwallowedException")
     private fun authenticate(token: String) {
         try {
             val email = jwtUtil.extractEmail(token)

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/security/RefreshTokenService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/security/RefreshTokenService.kt
@@ -46,6 +46,9 @@ class RefreshTokenService(
 
     // noRollbackFor: the 401 must NOT undo the family revocation written in this
     // same tx — otherwise reuse detection rolls itself back
+    // ThrowsCount: distinct 401 reasons (unknown / expired / already-used reuse detection),
+    // each with its own message — reuse detection especially must stay explicit.
+    @Suppress("ThrowsCount")
     @Transactional(noRollbackFor = [UnauthorizedException::class])
     fun rotate(rawToken: String): RotatedToken {
         val hash = sha256(rawToken)

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/util/EmailUtils.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/util/EmailUtils.kt
@@ -13,6 +13,8 @@ class EmailUtils(
 
     private val logger = LoggerFactory.getLogger(EmailUtils::class.java)
 
+    // TooGenericExceptionCaught: any send failure -> false, caller decides. Never throws.
+    @Suppress("TooGenericExceptionCaught")
     fun sendEmail(subject: String, body: String, to: String): Boolean {
         return try {
             val mimeMessage: MimeMessage = mailSender.createMimeMessage()
@@ -29,6 +31,8 @@ class EmailUtils(
         }
     }
 
+    // TooGenericExceptionCaught: any send failure -> false, caller decides. Never throws.
+    @Suppress("TooGenericExceptionCaught")
     fun sendEmailWithAttachment(
         subject: String,
         body: String,


### PR DESCRIPTION
Module: **shared**. Clears 16 findings (7 TooGenericExceptionCaught, 5 MaxLineLength, ThrowsCount, SwallowedException, SpreadOperator, LongParameterList).

- 7 catch-alls suppressed with per-site justification — audit/notification/email/status all log-and-continue; JwtAuthFilter leaves bad tokens unauthenticated (never 500).
- RefreshTokenService.rotate: ThrowsCount suppressed (distinct 401 reasons incl. reuse detection).
- StatusEmailService ctor: LongParameterList (Spring DI).
- WebConfig: SpreadOperator on `allowedOrigins(*..)`; CORS warn wrapped.
- RefreshTokenRepository @Query wrapped (JPQL byte-identical); entity FQNs shortened via imports in 2 repos.

**Note:** suppression-heavy, but each is a rule fighting a correct boundary/idiom (flagged for review). No behavior change, compiles. Closes #49. Based on #38.