### PR TITLE
refactor(user): auth-code complexity suppressions

### DIFF
--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/user/controller/AuthController.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/user/controller/AuthController.kt
@@ -19,6 +19,8 @@ import org.springframework.web.bind.annotation.RestController
 
 @RestController
 @RequestMapping("/api/auth")
+// LongParameterList: Spring constructor injection — each dependency is a distinct bean
+@Suppress("LongParameterList")
 class AuthController(
     private val userRepository: UserMasterRepository,
     private val workerRepository: WorkerMasterRepository,
@@ -30,6 +32,10 @@ class AuthController(
 ) {
 
     @PostMapping("/login")
+    // Auth entry point: nested admin/worker/user cascade with early 401s, wrapped in a boundary
+    // catch that turns anything unexpected into a 500. Flattening into per-account-type resolvers
+    // is a sensible follow-up.
+    @Suppress("LongMethod", "NestedBlockDepth", "ReturnCount", "TooGenericExceptionCaught", "SwallowedException")
     fun login(@RequestBody request: LoginRequest): ResponseEntity<Map<String, Any>> {
         // must stay outside the try — the catch below eats everything into a 500
         if (loginAttemptService.isLocked(request.email)) {

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/user/service/UserMgmtService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/user/service/UserMgmtService.kt
@@ -27,6 +27,8 @@ data class RegistrationResult(
 )
 
 @Service
+// TooManyFunctions: cohesive user lifecycle (register/activate/login/CRUD) in one service.
+@Suppress("TooManyFunctions")
 class UserMgmtService(
     private val userRepository: UserMasterRepository,
     private val passwordEncoder: PasswordEncoder,
@@ -95,6 +97,9 @@ class UserMgmtService(
         return "User activated successfully"
     }
 
+    // ThrowsCount: distinct auth failures (locked / unknown / bad password / not activated),
+    // each its own status; folding would blur the 401 reasons.
+    @Suppress("ThrowsCount")
     fun loginUser(request: LoginRequest): LoginResponse {
         if (loginAttemptService.isLocked(request.email)) {
             throw AccountLockedException(loginAttemptService.lockoutSeconds())

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/user/service/WorkerMgmtService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/user/service/WorkerMgmtService.kt
@@ -94,6 +94,9 @@ class WorkerMgmtService(
         return "Worker activated successfully"
     }
 
+    // ThrowsCount: distinct auth failures (locked / unknown / bad password / not activated),
+    // each its own status; folding would blur the 401 reasons.
+    @Suppress("ThrowsCount")
     fun loginWorker(request: LoginRequest): LoginResponse {
         if (loginAttemptService.isLocked(request.email)) {
             throw AccountLockedException(loginAttemptService.lockoutSeconds())


### PR DESCRIPTION
Module: **user** (final module). Clears 8 findings (LongMethod, NestedBlockDepth, ReturnCount, TooGenericExceptionCaught, SwallowedException, TooManyFunctions, 2 ThrowsCount).

All behavioral, all in the auth path — suppressed with justification rather than risk a rewrite of authentication:
- `AuthController.login`: nested admin/worker/user cascade + boundary 500 catch. Flattening into per-account-type resolvers is a good follow-up.
- `UserMgmtService`: TooManyFunctions — cohesive user lifecycle.
- `loginUser`/`loginWorker`: ThrowsCount — distinct 401 reasons (locked/unknown/bad-password/not-activated).

Annotation-only, no behavior change, compiles. Closes #48. Based on #38.