### PR TITLE
style: adopt detekt-formatting (ktlint) + auto-format repo

### DIFF
--- a/healthcare/pom.xml
+++ b/healthcare/pom.xml
@@ -261,13 +261,21 @@
                 <artifactId>detekt-maven-plugin</artifactId>
                 <version>1.23.7</version>
                 <configuration>
-                    <!-- strict: run detekt's default rule set, no baseline yet -->
+                    <!-- strict: default rules + formatting (ktlint) ruleset.
+                         check only verifies; run detekt with -DautoCorrect=true or the IDE to reformat. -->
                     <report>
                         <report>xml:${project.basedir}/target/detekt/detekt.xml</report>
                         <report>html:${project.basedir}/target/detekt/detekt.html</report>
                         <report>txt:${project.basedir}/target/detekt/detekt.txt</report>
                     </report>
                 </configuration>
+                <dependencies>
+                    <dependency>
+                        <groupId>io.gitlab.arturbosch.detekt</groupId>
+                        <artifactId>detekt-formatting</artifactId>
+                        <version>1.23.7</version>
+                    </dependency>
+                </dependencies>
             </plugin>
         </plugins>
     </build>

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/HealthcareApplication.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/HealthcareApplication.kt
@@ -10,5 +10,5 @@ class HealthcareApplication
 // and this runs once at startup so the array copy is irrelevant.
 @Suppress("SpreadOperator")
 fun main(args: Array<String>) {
-	runApplication<HealthcareApplication>(*args)
+    runApplication<HealthcareApplication>(*args)
 }

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/application/service/CitizenApplicationRegistrationService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/application/service/CitizenApplicationRegistrationService.kt
@@ -5,7 +5,6 @@ import com.lakshay.healthcare.application.dto.CitizenRegistrationResponse
 import com.lakshay.healthcare.shared.entity.CitizenAppRegistration
 import com.lakshay.healthcare.shared.repository.CitizenAppRegistrationRepository
 import com.lakshay.healthcare.ssa.service.SsnValidationService
-import com.lakshay.healthcare.shared.exception.InvalidSsnException
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/benefit/config/BatchConfig.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/benefit/config/BatchConfig.kt
@@ -53,8 +53,13 @@ class BatchConfig {
         // mask at extraction — SSN never leaves the app in full
         lineAggregator.setFieldExtractor { e ->
             arrayOf(
-                e.caseNo, e.holderName, maskSsnLast4(e.holderSSN),
-                e.planName, e.benefitAmt, e.bankName, e.accountNumber
+                e.caseNo,
+                e.holderName,
+                maskSsnLast4(e.holderSSN),
+                e.planName,
+                e.benefitAmt,
+                e.bankName,
+                e.accountNumber
             )
         }
 

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/casework/controller/CaseworkController.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/casework/controller/CaseworkController.kt
@@ -2,11 +2,11 @@ package com.lakshay.healthcare.casework.controller
 
 import com.lakshay.healthcare.casework.dto.AssignmentRequest
 import com.lakshay.healthcare.casework.dto.AssignmentResponse
+import com.lakshay.healthcare.casework.dto.CaseNoteRequest
+import com.lakshay.healthcare.casework.dto.CaseNoteResponse
 import com.lakshay.healthcare.casework.dto.DocumentReviewRequest
 import com.lakshay.healthcare.casework.dto.DocumentReviewResponse
 import com.lakshay.healthcare.casework.dto.DocumentSummaryResponse
-import com.lakshay.healthcare.casework.dto.CaseNoteRequest
-import com.lakshay.healthcare.casework.dto.CaseNoteResponse
 import com.lakshay.healthcare.casework.dto.QueueItemResponse
 import com.lakshay.healthcare.casework.dto.RfiRequest
 import com.lakshay.healthcare.casework.dto.RfiResponse

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/casework/service/CaseworkService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/casework/service/CaseworkService.kt
@@ -1,12 +1,12 @@
 package com.lakshay.healthcare.casework.service
 
 import com.lakshay.healthcare.casework.dto.AssignmentRequest
-import com.lakshay.healthcare.casework.dto.DocumentReviewRequest
-import com.lakshay.healthcare.casework.dto.DocumentReviewResponse
-import com.lakshay.healthcare.casework.dto.DocumentSummaryResponse
 import com.lakshay.healthcare.casework.dto.AssignmentResponse
 import com.lakshay.healthcare.casework.dto.CaseNoteRequest
 import com.lakshay.healthcare.casework.dto.CaseNoteResponse
+import com.lakshay.healthcare.casework.dto.DocumentReviewRequest
+import com.lakshay.healthcare.casework.dto.DocumentReviewResponse
+import com.lakshay.healthcare.casework.dto.DocumentSummaryResponse
 import com.lakshay.healthcare.casework.dto.QueueItemResponse
 import com.lakshay.healthcare.casework.dto.RfiRequest
 import com.lakshay.healthcare.casework.dto.RfiResponse
@@ -64,8 +64,11 @@ class CaseworkService(
         val citizenEmail = citizen.email
         val author = SecurityContextHolder.getContext().authentication?.name ?: "SYSTEM"
         val notice = notificationService.notifyPortal(
-            caseNo = caseNo, recipient = citizenEmail, noticeType = "RFI",
-            subject = "Information requested - Case #$caseNo", body = request.message
+            caseNo = caseNo,
+            recipient = citizenEmail,
+            noticeType = "RFI",
+            subject = "Information requested - Case #$caseNo",
+            body = request.message
         )
         caseNoteRepository.save(CaseNote(caseNo = caseNo, author = author, body = "RFI: ${request.message}"))
         auditService.record("RFI_SENT", "DcCase", caseNo.toString())
@@ -76,8 +79,12 @@ class CaseworkService(
     fun listDocuments(caseNo: Long): List<DocumentSummaryResponse> =
         documentRepository.findByCaseNo(caseNo).map {
             DocumentSummaryResponse(
-                it.docId, it.docType, it.fileName,
-                it.contentType, it.status, it.createdAt.toString()
+                it.docId,
+                it.docType,
+                it.fileName,
+                it.contentType,
+                it.status,
+                it.createdAt.toString()
             )
         }
 

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/citizen/controller/CitizenPortalController.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/citizen/controller/CitizenPortalController.kt
@@ -2,8 +2,8 @@ package com.lakshay.healthcare.citizen.controller
 
 import com.lakshay.healthcare.citizen.dto.ApplyResponse
 import com.lakshay.healthcare.citizen.dto.CaseStatusResponse
-import com.lakshay.healthcare.citizen.dto.DocumentResponse
 import com.lakshay.healthcare.citizen.dto.CitizenApplyRequest
+import com.lakshay.healthcare.citizen.dto.DocumentResponse
 import com.lakshay.healthcare.citizen.dto.NoticeResponse
 import com.lakshay.healthcare.citizen.service.CitizenPortalService
 import com.lakshay.healthcare.user.dto.RegisterRequest

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/citizen/service/CitizenPortalService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/citizen/service/CitizenPortalService.kt
@@ -16,8 +16,8 @@ import com.lakshay.healthcare.shared.exception.ResourceNotFoundException
 import com.lakshay.healthcare.shared.exception.ValidationException
 import com.lakshay.healthcare.shared.repository.CitizenAppRegistrationRepository
 import com.lakshay.healthcare.shared.repository.DcCaseRepository
-import com.lakshay.healthcare.shared.repository.EligibilityDetailsRepository
 import com.lakshay.healthcare.shared.repository.DocumentRepository
+import com.lakshay.healthcare.shared.repository.EligibilityDetailsRepository
 import com.lakshay.healthcare.shared.repository.NoticeRepository
 import com.lakshay.healthcare.shared.security.OwnershipService
 import org.springframework.security.core.context.SecurityContextHolder
@@ -62,8 +62,12 @@ class CitizenPortalService(
         val email = SecurityContextHolder.getContext().authentication?.name ?: "SYSTEM"
         val saved = documentRepository.save(
             Document(
-                caseNo = caseNo, uploadedBy = email, docType = docType.uppercase(),
-                fileName = file.originalFilename, contentType = file.contentType, content = file.bytes
+                caseNo = caseNo,
+                uploadedBy = email,
+                docType = docType.uppercase(),
+                fileName = file.originalFilename,
+                contentType = file.contentType,
+                content = file.bytes
             )
         )
         auditService.record("DOCUMENT_UPLOADED", "Document", saved.docId.toString(), "type=${docType.uppercase()}")
@@ -72,13 +76,19 @@ class CitizenPortalService(
         if (openRfis.isNotEmpty()) {
             openRfis.forEach { noticeRepository.save(it.copy(status = "RESOLVED")) }
             auditService.record(
-                "RFI_RESOLVED", "DcCase", caseNo.toString(),
+                "RFI_RESOLVED",
+                "DcCase",
+                caseNo.toString(),
                 "resolvedBy=docUpload count=${openRfis.size}"
             )
         }
         return DocumentResponse(
-            saved.docId, saved.docType, saved.fileName,
-            saved.contentType, saved.status, saved.createdAt.toString()
+            saved.docId,
+            saved.docType,
+            saved.fileName,
+            saved.contentType,
+            saved.status,
+            saved.createdAt.toString()
         )
     }
 
@@ -154,8 +164,13 @@ class CitizenPortalService(
         auditService.record("NOTICE_INBOX_VIEWED", "Notice", null, "own inbox")
         return noticeRepository.findByRecipientOrderByCreatedAtDesc(email).map {
             NoticeResponse(
-                it.noticeId, it.noticeType, it.subject, it.body,
-                it.status, it.createdAt.toString(), it.caseNo
+                it.noticeId,
+                it.noticeType,
+                it.subject,
+                it.body,
+                it.status,
+                it.createdAt.toString(),
+                it.caseNo
             )
         }
     }
@@ -168,8 +183,12 @@ class CitizenPortalService(
         if (!request.attested) throw ValidationException("attestation is required to submit an application")
         val reg = applicationService.registerCitizen(
             CitizenRegistrationRequest(
-                fullName = request.fullName, email = email, gender = request.gender,
-                phoneNo = request.phoneNo, ssn = request.ssn, dob = request.dob
+                fullName = request.fullName,
+                email = email,
+                gender = request.gender,
+                phoneNo = request.phoneNo,
+                ssn = request.ssn,
+                dob = request.dob
             )
         )
         val caseNo = dcCaseRepository.save(DcCase(appId = reg.appId)).caseNo

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/correspondence/service/CorrespondenceService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/correspondence/service/CorrespondenceService.kt
@@ -3,11 +3,11 @@
 import com.lakshay.healthcare.correspondence.dto.TriggerResponse
 import com.lakshay.healthcare.shared.entity.CoTrigger
 import com.lakshay.healthcare.shared.entity.EligibilityDetails
+import com.lakshay.healthcare.shared.notification.NotificationService
 import com.lakshay.healthcare.shared.repository.CitizenAppRegistrationRepository
 import com.lakshay.healthcare.shared.repository.CoTriggerRepository
 import com.lakshay.healthcare.shared.repository.DcCaseRepository
 import com.lakshay.healthcare.shared.repository.EligibilityDetailsRepository
-import com.lakshay.healthcare.shared.notification.NotificationService
 import com.lakshay.healthcare.shared.util.EmailUtils
 import com.lowagie.text.Document
 import com.lowagie.text.FontFactory

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/correspondence/service/RenewalReminderService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/correspondence/service/RenewalReminderService.kt
@@ -61,7 +61,9 @@ class RenewalReminderService(
             }
             else -> {
                 val notice = notificationService.notifyEmail(
-                    caseNo = caseNo, recipient = email, noticeType = type,
+                    caseNo = caseNo,
+                    recipient = email,
+                    noticeType = type,
                     subject = "Your ${planName ?: "plan"} renews soon - Case #$caseNo",
                     body = "Your ${planName ?: "plan"} coverage ends on $endDate ($days days away). " +
                         "Log in to your portal to renew before it lapses."

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/data/controller/DataCollectionController.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/data/controller/DataCollectionController.kt
@@ -1,6 +1,4 @@
-﻿package com.lakshay.healthcare.data.controller
-
-import com.lakshay.healthcare.data.dto.CaseResponse
+﻿package com.lakshay.healthcare.data.controller import com.lakshay.healthcare.data.dto.CaseResponse
 import com.lakshay.healthcare.data.dto.ChildrenRequest
 import com.lakshay.healthcare.data.dto.DcSummaryResponse
 import com.lakshay.healthcare.data.dto.EducationRequest

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/data/dto/DataDtos.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/data/dto/DataDtos.kt
@@ -1,6 +1,4 @@
-﻿package com.lakshay.healthcare.data.dto
-
-data class IncomeRequest(
+﻿package com.lakshay.healthcare.data.dto data class IncomeRequest(
     val caseNo: Long,
     val empIncome: Double? = null,
     val propertyIncome: Double? = null

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/data/service/DataCollectionService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/data/service/DataCollectionService.kt
@@ -1,6 +1,4 @@
-﻿package com.lakshay.healthcare.data.service
-
-import com.lakshay.healthcare.data.dto.CaseResponse
+﻿package com.lakshay.healthcare.data.service import com.lakshay.healthcare.data.dto.CaseResponse
 import com.lakshay.healthcare.data.dto.ChildrenRequest
 import com.lakshay.healthcare.data.dto.DcSummaryResponse
 import com.lakshay.healthcare.data.dto.EducationRequest
@@ -9,11 +7,15 @@ import com.lakshay.healthcare.data.dto.HouseholdMemberResponse
 import com.lakshay.healthcare.data.dto.IncomeRequest
 import com.lakshay.healthcare.data.dto.PlanNameResponse
 import com.lakshay.healthcare.data.dto.PlanSelectionRequest
+import com.lakshay.healthcare.shared.audit.AuditService
 import com.lakshay.healthcare.shared.entity.DcCase
 import com.lakshay.healthcare.shared.entity.DcChildren
 import com.lakshay.healthcare.shared.entity.DcEducation
 import com.lakshay.healthcare.shared.entity.DcIncome
 import com.lakshay.healthcare.shared.entity.HouseholdMember
+import com.lakshay.healthcare.shared.exception.DuplicateResourceException
+import com.lakshay.healthcare.shared.exception.ResourceNotFoundException
+import com.lakshay.healthcare.shared.exception.ValidationException
 import com.lakshay.healthcare.shared.repository.CitizenAppRegistrationRepository
 import com.lakshay.healthcare.shared.repository.DcCaseRepository
 import com.lakshay.healthcare.shared.repository.DcChildrenRepository
@@ -21,10 +23,6 @@ import com.lakshay.healthcare.shared.repository.DcEducationRepository
 import com.lakshay.healthcare.shared.repository.DcIncomeRepository
 import com.lakshay.healthcare.shared.repository.HouseholdMemberRepository
 import com.lakshay.healthcare.shared.repository.PlanRepository
-import com.lakshay.healthcare.shared.exception.DuplicateResourceException
-import com.lakshay.healthcare.shared.exception.ValidationException
-import com.lakshay.healthcare.shared.audit.AuditService
-import com.lakshay.healthcare.shared.exception.ResourceNotFoundException
 import org.springframework.stereotype.Service
 import java.time.LocalDate
 
@@ -117,7 +115,9 @@ class DataCollectionService(
             )
         )
         auditService.record(
-            "HOUSEHOLD_MEMBER_ADDED", "HouseholdMember", saved.memberId.toString(),
+            "HOUSEHOLD_MEMBER_ADDED",
+            "HouseholdMember",
+            saved.memberId.toString(),
             "relationship=${request.relationship}"
         )
         return saved.memberId
@@ -150,8 +150,12 @@ class DataCollectionService(
             },
             householdMembers = householdMembers.map {
                 HouseholdMemberResponse(
-                    it.memberId, it.caseNo, it.fullName,
-                    it.relationship, it.dob?.toString(), it.memberIncome
+                    it.memberId,
+                    it.caseNo,
+                    it.fullName,
+                    it.relationship,
+                    it.dob?.toString(),
+                    it.memberIncome
                 )
             },
             householdSize = 1 + householdMembers.size

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/eligibility/service/EligibilityDeterminationService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/eligibility/service/EligibilityDeterminationService.kt
@@ -3,15 +3,16 @@
 import com.lakshay.healthcare.eligibility.dto.EligibilityResponse
 import com.lakshay.healthcare.eligibility.dto.ProgramResult
 import com.lakshay.healthcare.eligibility.dto.ScreeningResponse
+import com.lakshay.healthcare.shared.audit.AuditService
 import com.lakshay.healthcare.shared.entity.CoTrigger
 import com.lakshay.healthcare.shared.entity.DcChildren
 import com.lakshay.healthcare.shared.entity.DcEducation
 import com.lakshay.healthcare.shared.entity.DcIncome
 import com.lakshay.healthcare.shared.entity.EligibilityDetails
 import com.lakshay.healthcare.shared.exception.ResourceNotFoundException
-import com.lakshay.healthcare.shared.audit.AuditService
 import com.lakshay.healthcare.shared.lifecycle.CaseStateMachine
 import com.lakshay.healthcare.shared.lifecycle.CaseStatus
+import com.lakshay.healthcare.shared.notification.StatusEmailService
 import com.lakshay.healthcare.shared.repository.CitizenAppRegistrationRepository
 import com.lakshay.healthcare.shared.repository.CoTriggerRepository
 import com.lakshay.healthcare.shared.repository.DcCaseRepository
@@ -22,7 +23,6 @@ import com.lakshay.healthcare.shared.repository.EligibilityDetailsRepository
 import com.lakshay.healthcare.shared.repository.HouseholdMemberRepository
 import com.lakshay.healthcare.shared.repository.PlanRepository
 import com.lakshay.healthcare.shared.repository.PlanRuleRepository
-import com.lakshay.healthcare.shared.notification.StatusEmailService
 import com.lakshay.healthcare.shared.security.OwnershipService
 import org.springframework.stereotype.Service
 import java.time.LocalDate
@@ -121,7 +121,9 @@ class EligibilityDeterminationService(
         // case went through eligibility -> mark DETERMINED (idempotent on re-run)
         dcCaseRepository.save(caseStateMachine.transition(dcCase, CaseStatus.DETERMINED))
         auditService.record(
-            "CASE_DETERMINED", "DcCase", caseNo.toString(),
+            "CASE_DETERMINED",
+            "DcCase",
+            caseNo.toString(),
             "planStatus=${output.planStatus}; " +
                 "applicantIncome=${income.empIncome ?: 0.0}; householdIncome=$householdIncome"
         )
@@ -130,9 +132,13 @@ class EligibilityDeterminationService(
         if (existing?.planStatus != output.planStatus) {
             citizen?.email?.let { email ->
                 statusEmailService.caseStatusChanged(
-                    caseNo = caseNo, recipient = email, citizenName = citizenName,
-                    status = output.planStatus ?: "UNKNOWN", planName = planName,
-                    benefitAmt = output.benefitAmt, denialReason = output.denialReason
+                    caseNo = caseNo,
+                    recipient = email,
+                    citizenName = citizenName,
+                    status = output.planStatus ?: "UNKNOWN",
+                    planName = planName,
+                    benefitAmt = output.benefitAmt,
+                    denialReason = output.denialReason
                 )
             }
         }

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/report/service/GovernmentReportService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/report/service/GovernmentReportService.kt
@@ -11,7 +11,6 @@ import com.lakshay.healthcare.shared.repository.PlanRepository
 import jakarta.servlet.http.HttpServletResponse
 import org.springframework.stereotype.Service
 import org.springframework.util.FileCopyUtils
-import java.io.ByteArrayOutputStream
 import java.nio.charset.StandardCharsets
 import java.time.LocalDate
 
@@ -45,7 +44,7 @@ class GovernmentReportService(
             reportFormat = request.reportFormat,
             reportStatus = "GENERATED",
             reportDescription = "Government report for ${request.periodCovered ?: "current period"}",
-            reportFilePath = "reports/government/${reportName}.${request.reportFormat.lowercase()}",
+            reportFilePath = "reports/government/$reportName.${request.reportFormat.lowercase()}",
             generatedFor = request.generatedFor ?: "Department of Health",
             departmentName = request.departmentName ?: "Health Insurance Department",
             periodCovered = request.periodCovered ?: LocalDate.now().month.toString(),
@@ -119,7 +118,7 @@ class GovernmentReportService(
             appendLine("Type: ${request.reportType}")
             appendLine("Period: ${request.periodCovered ?: "Current"}")
             appendLine("Generated: ${LocalDate.now()}")
-            appendLine("=" .repeat(SEPARATOR_LENGTH))
+            appendLine("=".repeat(SEPARATOR_LENGTH))
             appendLine()
             appendLine("APPLICATION STATISTICS")
             appendLine("Total Applications: $totalApplications")
@@ -138,7 +137,7 @@ class GovernmentReportService(
             appendLine("BENEFIT STATISTICS")
             appendLine("Total Eligible Citizens: $approvedCount")
             appendLine("Total Denied: $deniedCount")
-            appendLine("=" .repeat(SEPARATOR_LENGTH))
+            appendLine("=".repeat(SEPARATOR_LENGTH))
             appendLine("End of Report")
         }
     }

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/config/SecurityConfig.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/config/SecurityConfig.kt
@@ -4,7 +4,6 @@ import com.lakshay.healthcare.shared.security.AuthEntryPoint
 import com.lakshay.healthcare.shared.security.JwtAuthFilter
 import com.lakshay.healthcare.shared.security.RateLimitFilter
 import org.springframework.beans.factory.annotation.Value
-import java.time.Duration
 import org.springframework.context.annotation.Bean
 import org.springframework.context.annotation.Configuration
 import org.springframework.http.HttpMethod
@@ -15,6 +14,7 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.security.web.SecurityFilterChain
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter
+import java.time.Duration
 
 @Configuration
 @EnableWebSecurity

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/exception/GlobalExceptionHandler.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/exception/GlobalExceptionHandler.kt
@@ -1,17 +1,17 @@
 ﻿package com.lakshay.healthcare.shared.exception
 
+import com.lakshay.healthcare.shared.exception.DuplicateResourceException
+import com.lakshay.healthcare.shared.exception.InvalidSsnException
+import com.lakshay.healthcare.shared.exception.ResourceNotFoundException
+import com.lakshay.healthcare.shared.exception.UnauthorizedException
 import org.slf4j.LoggerFactory
 import org.springframework.http.HttpStatus
 import org.springframework.http.ResponseEntity
 import org.springframework.web.bind.annotation.ControllerAdvice
 import org.springframework.web.bind.annotation.ExceptionHandler
-import org.springframework.web.multipart.MaxUploadSizeExceededException
 import org.springframework.web.context.request.WebRequest
+import org.springframework.web.multipart.MaxUploadSizeExceededException
 import java.time.LocalDateTime
-import com.lakshay.healthcare.shared.exception.InvalidSsnException
-import com.lakshay.healthcare.shared.exception.ResourceNotFoundException
-import com.lakshay.healthcare.shared.exception.DuplicateResourceException
-import com.lakshay.healthcare.shared.exception.UnauthorizedException
 
 @ControllerAdvice
 class GlobalExceptionHandler {

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/notification/NotificationService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/notification/NotificationService.kt
@@ -24,9 +24,14 @@ class NotificationService(
         try {
             noticeRepository.save(
                 Notice(
-                    caseNo = caseNo, recipient = recipient, channel = "PORTAL",
-                    noticeType = noticeType, subject = subject, body = body,
-                    status = "SENT", sentAt = LocalDateTime.now()
+                    caseNo = caseNo,
+                    recipient = recipient,
+                    channel = "PORTAL",
+                    noticeType = noticeType,
+                    subject = subject,
+                    body = body,
+                    status = "SENT",
+                    sentAt = LocalDateTime.now()
                 )
             )
         } catch (e: Exception) {
@@ -41,8 +46,13 @@ class NotificationService(
         try {
             val saved = noticeRepository.save(
                 Notice(
-                    caseNo = caseNo, recipient = recipient, channel = "EMAIL",
-                    noticeType = noticeType, subject = subject, body = body, status = "PENDING"
+                    caseNo = caseNo,
+                    recipient = recipient,
+                    channel = "EMAIL",
+                    noticeType = noticeType,
+                    subject = subject,
+                    body = body,
+                    status = "PENDING"
                 )
             )
             val ok = emailUtils.sendEmail(subject, body, recipient)

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/notification/StatusEmailService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/notification/StatusEmailService.kt
@@ -32,21 +32,35 @@ class StatusEmailService(
             else -> "Case update - Case #$caseNo"
         }
         send(
-            caseNo, recipient, "STATUS_CHANGE", subject,
+            caseNo,
+            recipient,
+            "STATUS_CHANGE",
+            subject,
             mapOf(
-                "citizenName" to citizenName, "caseNo" to caseNo, "status" to status,
-                "planName" to planName, "benefitAmt" to benefitAmt,
-                "denialReason" to denialReason, "message" to null
+                "citizenName" to citizenName,
+                "caseNo" to caseNo,
+                "status" to status,
+                "planName" to planName,
+                "benefitAmt" to benefitAmt,
+                "denialReason" to denialReason,
+                "message" to null
             )
         )
     }
 
     fun rfiOpened(caseNo: Long, recipient: String, citizenName: String, message: String) {
         send(
-            caseNo, recipient, "RFI", "Information requested - Case #$caseNo",
+            caseNo,
+            recipient,
+            "RFI",
+            "Information requested - Case #$caseNo",
             mapOf(
-                "citizenName" to citizenName, "caseNo" to caseNo, "status" to "RFI",
-                "planName" to null, "benefitAmt" to null, "denialReason" to null,
+                "citizenName" to citizenName,
+                "caseNo" to caseNo,
+                "status" to "RFI",
+                "planName" to null,
+                "benefitAmt" to null,
+                "denialReason" to null,
                 "message" to message
             )
         )

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/repository/EligibilityDetailsRepository.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/repository/EligibilityDetailsRepository.kt
@@ -1,11 +1,11 @@
 ﻿package com.lakshay.healthcare.shared.repository
 
 import com.lakshay.healthcare.shared.entity.EligibilityDetails
-import java.time.LocalDate
 import org.springframework.data.domain.Page
 import org.springframework.data.domain.Pageable
 import org.springframework.data.jpa.repository.JpaRepository
 import org.springframework.stereotype.Repository
+import java.time.LocalDate
 
 @Repository
 interface EligibilityDetailsRepository : JpaRepository<EligibilityDetails, Long> {

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/security/JwtUtil.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/security/JwtUtil.kt
@@ -51,10 +51,10 @@ class JwtUtil(
         val claims = extractAllClaims(token)
         // audience is a Set in jjwt 0.12+; pre-upgrade tokens carried a plain string
         // and the parser folds those into a singleton set, so contains() covers both
-        return claims.subject == email
-                && claims.issuer == issuer
-                && claims.audience?.contains(audience) == true
-                && !isTokenExpired(token)
+        return claims.subject == email &&
+            claims.issuer == issuer &&
+            claims.audience?.contains(audience) == true &&
+            !isTokenExpired(token)
     }
 
     private fun extractAllClaims(token: String): Claims =

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/security/LoginAttemptService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/security/LoginAttemptService.kt
@@ -25,6 +25,7 @@ class LoginAttemptService(
 
     private class Attempts {
         val failures = AtomicInteger()
+
         @Volatile
         var lockedUntil: Instant? = null
     }

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/user/service/UserMgmtService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/user/service/UserMgmtService.kt
@@ -2,19 +2,19 @@
 
 import com.lakshay.healthcare.admin.dto.UserDataResponse
 import com.lakshay.healthcare.shared.entity.UserMaster
+import com.lakshay.healthcare.shared.exception.AccountLockedException
+import com.lakshay.healthcare.shared.exception.DuplicateResourceException
+import com.lakshay.healthcare.shared.exception.ResourceNotFoundException
+import com.lakshay.healthcare.shared.exception.UnauthorizedException
 import com.lakshay.healthcare.shared.repository.UserMasterRepository
 import com.lakshay.healthcare.shared.security.JwtUtil
+import com.lakshay.healthcare.shared.security.LoginAttemptService
+import com.lakshay.healthcare.shared.security.RefreshTokenService
 import com.lakshay.healthcare.shared.util.EmailUtils
 import com.lakshay.healthcare.user.dto.ActivateRequest
 import com.lakshay.healthcare.user.dto.LoginRequest
 import com.lakshay.healthcare.user.dto.LoginResponse
 import com.lakshay.healthcare.user.dto.RegisterRequest
-import com.lakshay.healthcare.shared.exception.DuplicateResourceException
-import com.lakshay.healthcare.shared.exception.ResourceNotFoundException
-import com.lakshay.healthcare.shared.exception.AccountLockedException
-import com.lakshay.healthcare.shared.exception.UnauthorizedException
-import com.lakshay.healthcare.shared.security.LoginAttemptService
-import com.lakshay.healthcare.shared.security.RefreshTokenService
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import java.security.SecureRandom
@@ -201,8 +201,8 @@ class UserMgmtService(
         return """
             <h2>Welcome to Insurance System for Health</h2>
             <p>Your registration was successful.</p>
-            <p>User ID: ${userId}</p>
-            <p>Your temporary password is: <b>${tempPwd}</b></p>
+            <p>User ID: $userId</p>
+            <p>Your temporary password is: <b>$tempPwd</b></p>
             <p>Please use your registered email and this temporary password to activate your account.</p>
             <p>Activation URL: http://localhost:8080/user-api/activate</p>
             <p>Provide your email, temporary password, and a new password of your choice to activate.</p>

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/user/service/WorkerMgmtService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/user/service/WorkerMgmtService.kt
@@ -2,19 +2,19 @@
 
 import com.lakshay.healthcare.admin.dto.WorkerDataResponse
 import com.lakshay.healthcare.shared.entity.WorkerMaster
+import com.lakshay.healthcare.shared.exception.AccountLockedException
+import com.lakshay.healthcare.shared.exception.DuplicateResourceException
+import com.lakshay.healthcare.shared.exception.ResourceNotFoundException
+import com.lakshay.healthcare.shared.exception.UnauthorizedException
 import com.lakshay.healthcare.shared.repository.WorkerMasterRepository
 import com.lakshay.healthcare.shared.security.JwtUtil
+import com.lakshay.healthcare.shared.security.LoginAttemptService
+import com.lakshay.healthcare.shared.security.RefreshTokenService
 import com.lakshay.healthcare.shared.util.EmailUtils
 import com.lakshay.healthcare.user.dto.ActivateRequest
 import com.lakshay.healthcare.user.dto.LoginRequest
 import com.lakshay.healthcare.user.dto.LoginResponse
 import com.lakshay.healthcare.user.dto.RegisterRequest
-import com.lakshay.healthcare.shared.exception.DuplicateResourceException
-import com.lakshay.healthcare.shared.exception.ResourceNotFoundException
-import com.lakshay.healthcare.shared.exception.AccountLockedException
-import com.lakshay.healthcare.shared.exception.UnauthorizedException
-import com.lakshay.healthcare.shared.security.LoginAttemptService
-import com.lakshay.healthcare.shared.security.RefreshTokenService
 import org.springframework.security.crypto.password.PasswordEncoder
 import org.springframework.stereotype.Service
 import java.security.SecureRandom
@@ -201,8 +201,8 @@ class WorkerMgmtService(
         return """
             <h2>Welcome to Insurance System for Health</h2>
             <p>Your worker registration was successful.</p>
-            <p>Worker ID: ${workerId}</p>
-            <p>Your temporary password is: <b>${tempPwd}</b></p>
+            <p>Worker ID: $workerId</p>
+            <p>Your temporary password is: <b>$tempPwd</b></p>
             <p>Please use your registered email and this temporary password to activate your account.</p>
             <p>Activation URL: http://localhost:8080/worker-api/activate</p>
             <p>Provide your email, temporary password, and a new password of your choice to activate.</p>

--- a/healthcare/src/test/kotlin/com/lakshay/healthcare/AdminManagementIT.kt
+++ b/healthcare/src/test/kotlin/com/lakshay/healthcare/AdminManagementIT.kt
@@ -1,8 +1,8 @@
 package com.lakshay.healthcare
 
 import com.lakshay.healthcare.admin.dto.WorkerDataResponse
-import com.lakshay.healthcare.user.dto.RegisterRequest
 import com.lakshay.healthcare.support.IntegrationTestBase
+import com.lakshay.healthcare.user.dto.RegisterRequest
 import org.assertj.core.api.Assertions.assertThat
 import org.junit.jupiter.api.Test
 import org.springframework.http.HttpHeaders
@@ -82,8 +82,11 @@ class AdminManagementIT : IntegrationTestBase() {
                 .content(
                     json(
                         RegisterRequest(
-                            name = "Wendy Worker", password = "ignored", email = "wendy@ish.test",
-                            gender = "F", designation = "Caseworker"
+                            name = "Wendy Worker",
+                            password = "ignored",
+                            email = "wendy@ish.test",
+                            gender = "F",
+                            designation = "Caseworker"
                         )
                     )
                 )

--- a/healthcare/src/test/kotlin/com/lakshay/healthcare/BenefitIssuanceIT.kt
+++ b/healthcare/src/test/kotlin/com/lakshay/healthcare/BenefitIssuanceIT.kt
@@ -28,16 +28,23 @@ class BenefitIssuanceIT : IntegrationTestBase() {
     private fun approved(caseNo: Long, ssn: Long = 123456704L): EligibilityDetails =
         eligibilityRepository.save(
             EligibilityDetails(
-                caseNo = caseNo, holderName = "Jane Doe", holderSSN = ssn,
-                planName = "SNAP", planStatus = "APPROVED", benefitAmt = 200.0
+                caseNo = caseNo,
+                holderName = "Jane Doe",
+                holderSSN = ssn,
+                planName = "SNAP",
+                planStatus = "APPROVED",
+                benefitAmt = 200.0
             )
         )
 
     private fun denied(caseNo: Long): EligibilityDetails =
         eligibilityRepository.save(
             EligibilityDetails(
-                caseNo = caseNo, holderName = "Bob Roe", planName = "SNAP",
-                planStatus = "DENIED", denialReason = "High Income"
+                caseNo = caseNo,
+                holderName = "Bob Roe",
+                planName = "SNAP",
+                planStatus = "DENIED",
+                denialReason = "High Income"
             )
         )
 

--- a/healthcare/src/test/kotlin/com/lakshay/healthcare/CaseTimelineIT.kt
+++ b/healthcare/src/test/kotlin/com/lakshay/healthcare/CaseTimelineIT.kt
@@ -18,8 +18,11 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 class CaseTimelineIT : IntegrationTestBase() {
 
     @Autowired lateinit var eligibilityService: EligibilityDeterminationService
+
     @Autowired lateinit var citizenRepo: CitizenAppRegistrationRepository
+
     @Autowired lateinit var dcCaseRepo: DcCaseRepository
+
     @Autowired lateinit var dcIncomeRepo: DcIncomeRepository
 
     private val ownerEmail = "timeline@ish.test"
@@ -27,8 +30,11 @@ class CaseTimelineIT : IntegrationTestBase() {
     private fun seedCase(): Long {
         val app = citizenRepo.save(
             CitizenAppRegistration(
-                fullName = "Tim Line", email = ownerEmail, gender = "M",
-                ssn = 123456705L, stateName = "California"
+                fullName = "Tim Line",
+                email = ownerEmail,
+                gender = "M",
+                ssn = 123456705L,
+                stateName = "California"
             )
         )
         val case = dcCaseRepo.save(DcCase(appId = app.appId, planId = planId("SNAP")))

--- a/healthcare/src/test/kotlin/com/lakshay/healthcare/CaseworkIT.kt
+++ b/healthcare/src/test/kotlin/com/lakshay/healthcare/CaseworkIT.kt
@@ -20,14 +20,21 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 class CaseworkIT : IntegrationTestBase() {
 
     @Autowired private lateinit var citizenRepo: CitizenAppRegistrationRepository
+
     @Autowired private lateinit var dcCaseRepo: DcCaseRepository
+
     @Autowired private lateinit var noticeRepo: com.lakshay.healthcare.shared.repository.NoticeRepository
+
     @Autowired private lateinit var documentRepo: com.lakshay.healthcare.shared.repository.DocumentRepository
 
     private fun seedCase(name: String = "Jane Doe"): Long {
         val app = citizenRepo.save(
             CitizenAppRegistration(
-                fullName = name, email = "c@ish.test", gender = "F", ssn = 123456704L, stateName = "California"
+                fullName = name,
+                email = "c@ish.test",
+                gender = "F",
+                ssn = 123456704L,
+                stateName = "California"
             )
         )
         return dcCaseRepo.save(DcCase(appId = app.appId)).caseNo
@@ -194,8 +201,11 @@ class CaseworkIT : IntegrationTestBase() {
         val caseNo = seedCase()
         val docId = documentRepo.save(
             com.lakshay.healthcare.shared.entity.Document(
-                caseNo = caseNo, uploadedBy = "c@ish.test", docType = "ID",
-                contentType = "application/pdf", content = byteArrayOf(1, 2, 3)
+                caseNo = caseNo,
+                uploadedBy = "c@ish.test",
+                docType = "ID",
+                contentType = "application/pdf",
+                content = byteArrayOf(1, 2, 3)
             )
         ).docId
 
@@ -218,7 +228,10 @@ class CaseworkIT : IntegrationTestBase() {
         val caseNo = seedCase()
         val docId = documentRepo.save(
             com.lakshay.healthcare.shared.entity.Document(
-                caseNo = caseNo, uploadedBy = "x", docType = "ID", content = byteArrayOf(1)
+                caseNo = caseNo,
+                uploadedBy = "x",
+                docType = "ID",
+                content = byteArrayOf(1)
             )
         ).docId
         mockMvc.perform(

--- a/healthcare/src/test/kotlin/com/lakshay/healthcare/CitizenPortalIT.kt
+++ b/healthcare/src/test/kotlin/com/lakshay/healthcare/CitizenPortalIT.kt
@@ -15,8 +15,8 @@ import org.junit.jupiter.api.Test
 import org.springframework.beans.factory.annotation.Autowired
 import org.springframework.http.HttpHeaders
 import org.springframework.http.MediaType
-import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.mock.web.MockMultipartFile
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.multipart
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath
@@ -25,22 +25,31 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 class CitizenPortalIT : IntegrationTestBase() {
 
     @Autowired private lateinit var citizenRepo: CitizenAppRegistrationRepository
+
     @Autowired private lateinit var dcCaseRepo: DcCaseRepository
+
     @Autowired private lateinit var eligibilityRepo: EligibilityDetailsRepository
+
     @Autowired private lateinit var noticeRepo: com.lakshay.healthcare.shared.repository.NoticeRepository
 
     private fun seedCaseFor(email: String): Long {
         val app = citizenRepo.save(
             CitizenAppRegistration(
-                fullName = "Jane Doe", email = email, gender = "F",
-                ssn = 123456704L, stateName = "California"
+                fullName = "Jane Doe",
+                email = email,
+                gender = "F",
+                ssn = 123456704L,
+                stateName = "California"
             )
         )
         val caseNo = dcCaseRepo.save(DcCase(appId = app.appId)).caseNo
         eligibilityRepo.save(
             EligibilityDetails(
-                caseNo = caseNo, holderName = "Jane Doe",
-                planName = "SNAP", planStatus = "APPROVED", benefitAmt = 200.0
+                caseNo = caseNo,
+                holderName = "Jane Doe",
+                planName = "SNAP",
+                planStatus = "APPROVED",
+                benefitAmt = 200.0
             )
         )
         return caseNo
@@ -96,10 +105,16 @@ class CitizenPortalIT : IntegrationTestBase() {
         mockMvc.perform(
             post("/citizen-api/register").with(servletPath("/citizen-api/register"))
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(json(RegisterRequest(
-                    name = "New Citizen", password = "ignored",
-                    email = "newcit@ish.test", gender = "F"
-                )))
+                .content(
+                    json(
+                        RegisterRequest(
+                            name = "New Citizen",
+                            password = "ignored",
+                            email = "newcit@ish.test",
+                            gender = "F"
+                        )
+                    )
+                )
         )
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.userId").isNumber)
@@ -112,8 +127,12 @@ class CitizenPortalIT : IntegrationTestBase() {
     fun `activated citizen logs in with ROLE_CITIZEN`() {
         userRepository.save(
             UserMaster(
-                name = "Active Citizen", password = passwordEncoder.encode("pass123"),
-                email = "active.cit@ish.test", gender = "F", activeSw = "Y", role = "CITIZEN"
+                name = "Active Citizen",
+                password = passwordEncoder.encode("pass123"),
+                email = "active.cit@ish.test",
+                gender = "F",
+                activeSw = "Y",
+                role = "CITIZEN"
             )
         )
         mockMvc.perform(
@@ -127,14 +146,24 @@ class CitizenPortalIT : IntegrationTestBase() {
 
     @Test
     fun `CITIZEN sees only own notices`() {
-        noticeRepo.save(com.lakshay.healthcare.shared.entity.Notice(
-            recipient = "me@ish.test", channel = "PORTAL",
-            noticeType = "PLAN_DECISION", subject = "yours", body = "b"
-        ))
-        noticeRepo.save(com.lakshay.healthcare.shared.entity.Notice(
-            recipient = "other@ish.test", channel = "PORTAL",
-            noticeType = "PLAN_DECISION", subject = "theirs", body = "b"
-        ))
+        noticeRepo.save(
+            com.lakshay.healthcare.shared.entity.Notice(
+                recipient = "me@ish.test",
+                channel = "PORTAL",
+                noticeType = "PLAN_DECISION",
+                subject = "yours",
+                body = "b"
+            )
+        )
+        noticeRepo.save(
+            com.lakshay.healthcare.shared.entity.Notice(
+                recipient = "other@ish.test",
+                channel = "PORTAL",
+                noticeType = "PLAN_DECISION",
+                subject = "theirs",
+                body = "b"
+            )
+        )
         mockMvc.perform(
             get("/citizen-api/notices").header(HttpHeaders.AUTHORIZATION, bearer("ROLE_CITIZEN", "me@ish.test"))
         )
@@ -154,10 +183,16 @@ class CitizenPortalIT : IntegrationTestBase() {
             post("/citizen-api/applications")
                 .header(HttpHeaders.AUTHORIZATION, bearer("ROLE_CITIZEN", "applicant@ish.test"))
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(json(com.lakshay.healthcare.citizen.dto.CitizenApplyRequest(
-                    fullName = "Jane Doe", gender = "F",
-                    ssn = 123456704L, attested = true
-                )))
+                .content(
+                    json(
+                        com.lakshay.healthcare.citizen.dto.CitizenApplyRequest(
+                            fullName = "Jane Doe",
+                            gender = "F",
+                            ssn = 123456704L,
+                            attested = true
+                        )
+                    )
+                )
         )
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.stateName").value("California"))
@@ -173,10 +208,16 @@ class CitizenPortalIT : IntegrationTestBase() {
             post("/citizen-api/applications")
                 .header(HttpHeaders.AUTHORIZATION, bearer("ROLE_CITIZEN", "a@ish.test"))
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(json(com.lakshay.healthcare.citizen.dto.CitizenApplyRequest(
-                    fullName = "A", gender = "F",
-                    ssn = 123456704L, attested = false
-                )))
+                .content(
+                    json(
+                        com.lakshay.healthcare.citizen.dto.CitizenApplyRequest(
+                            fullName = "A",
+                            gender = "F",
+                            ssn = 123456704L,
+                            attested = false
+                        )
+                    )
+                )
         ).andExpect(status().isBadRequest)
     }
 
@@ -186,10 +227,16 @@ class CitizenPortalIT : IntegrationTestBase() {
             post("/citizen-api/applications")
                 .header(HttpHeaders.AUTHORIZATION, bearer("ROLE_CITIZEN", "a@ish.test"))
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(json(com.lakshay.healthcare.citizen.dto.CitizenApplyRequest(
-                    fullName = "A", gender = "F",
-                    ssn = 123L, attested = true
-                )))
+                .content(
+                    json(
+                        com.lakshay.healthcare.citizen.dto.CitizenApplyRequest(
+                            fullName = "A",
+                            gender = "F",
+                            ssn = 123L,
+                            attested = true
+                        )
+                    )
+                )
         ).andExpect(status().isBadRequest)
     }
 
@@ -198,10 +245,16 @@ class CitizenPortalIT : IntegrationTestBase() {
         mockMvc.perform(
             post("/citizen-api/applications")
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(json(com.lakshay.healthcare.citizen.dto.CitizenApplyRequest(
-                    fullName = "A", gender = "F",
-                    ssn = 123456704L, attested = true
-                )))
+                .content(
+                    json(
+                        com.lakshay.healthcare.citizen.dto.CitizenApplyRequest(
+                            fullName = "A",
+                            gender = "F",
+                            ssn = 123456704L,
+                            attested = true
+                        )
+                    )
+                )
         ).andExpect(status().isUnauthorized)
     }
 

--- a/healthcare/src/test/kotlin/com/lakshay/healthcare/CitizenRegistrationIT.kt
+++ b/healthcare/src/test/kotlin/com/lakshay/healthcare/CitizenRegistrationIT.kt
@@ -34,9 +34,18 @@ class CitizenRegistrationIT : IntegrationTestBase() {
     ): ResultActions = mockMvc.perform(
         post("/CitizenAR-api/save").header(HttpHeaders.AUTHORIZATION, adminAuth())
             .contentType(MediaType.APPLICATION_JSON)
-            .content(json(CitizenRegistrationRequest(
-                fullName, email, gender = "F", phoneNo = 5551234L, ssn = ssn, dob = dob
-            )))
+            .content(
+                json(
+                    CitizenRegistrationRequest(
+                        fullName,
+                        email,
+                        gender = "F",
+                        phoneNo = 5551234L,
+                        ssn = ssn,
+                        dob = dob
+                    )
+                )
+            )
     )
 
     @Test

--- a/healthcare/src/test/kotlin/com/lakshay/healthcare/CorrespondenceIT.kt
+++ b/healthcare/src/test/kotlin/com/lakshay/healthcare/CorrespondenceIT.kt
@@ -33,8 +33,11 @@ import java.time.LocalDate
 class CorrespondenceIT : IntegrationTestBase() {
 
     @Autowired private lateinit var citizenRepo: CitizenAppRegistrationRepository
+
     @Autowired private lateinit var dcCaseRepo: DcCaseRepository
+
     @Autowired private lateinit var eligibilityRepository: EligibilityDetailsRepository
+
     @Autowired private lateinit var coTriggerRepository: CoTriggerRepository
 
     /** Seed citizen -> case -> approved eligibility, returning the case number. */
@@ -44,15 +47,23 @@ class CorrespondenceIT : IntegrationTestBase() {
     ): Long {
         val app = citizenRepo.save(
             CitizenAppRegistration(
-                fullName = "Jane Doe", email = email, gender = "F",
-                ssn = ssn, stateName = "California", dob = LocalDate.of(1990, 1, 1)
+                fullName = "Jane Doe",
+                email = email,
+                gender = "F",
+                ssn = ssn,
+                stateName = "California",
+                dob = LocalDate.of(1990, 1, 1)
             )
         )
         val case = dcCaseRepo.save(DcCase(appId = app.appId, planId = planId("SNAP")))
         eligibilityRepository.save(
             EligibilityDetails(
-                caseNo = case.caseNo, holderName = "Jane Doe", holderSSN = ssn,
-                planName = "SNAP", planStatus = "APPROVED", benefitAmt = 200.0
+                caseNo = case.caseNo,
+                holderName = "Jane Doe",
+                holderSSN = ssn,
+                planName = "SNAP",
+                planStatus = "APPROVED",
+                benefitAmt = 200.0
             )
         )
         return case.caseNo

--- a/healthcare/src/test/kotlin/com/lakshay/healthcare/DataCollectionIT.kt
+++ b/healthcare/src/test/kotlin/com/lakshay/healthcare/DataCollectionIT.kt
@@ -35,9 +35,13 @@ import java.time.LocalDate
 class DataCollectionIT : IntegrationTestBase() {
 
     @Autowired private lateinit var citizenRepo: CitizenAppRegistrationRepository
+
     @Autowired private lateinit var dcCaseRepo: DcCaseRepository
+
     @Autowired private lateinit var dcIncomeRepo: DcIncomeRepository
+
     @Autowired private lateinit var dcEducationRepo: DcEducationRepository
+
     @Autowired private lateinit var dcChildrenRepo: DcChildrenRepository
 
     private fun seedCitizen(
@@ -45,8 +49,12 @@ class DataCollectionIT : IntegrationTestBase() {
         fullName: String = "Jane Doe"
     ): Long = citizenRepo.save(
         CitizenAppRegistration(
-            fullName = fullName, email = "citizen@ish.test", gender = "F",
-            ssn = ssn, stateName = "California", dob = LocalDate.of(1990, 1, 1)
+            fullName = fullName,
+            email = "citizen@ish.test",
+            gender = "F",
+            ssn = ssn,
+            stateName = "California",
+            dob = LocalDate.of(1990, 1, 1)
         )
     ).appId
 

--- a/healthcare/src/test/kotlin/com/lakshay/healthcare/EligibilityMatrixIT.kt
+++ b/healthcare/src/test/kotlin/com/lakshay/healthcare/EligibilityMatrixIT.kt
@@ -44,14 +44,23 @@ import java.time.LocalDate
 class EligibilityMatrixIT : IntegrationTestBase() {
 
     @Autowired private lateinit var eligibilityService: EligibilityDeterminationService
+
     @Autowired private lateinit var citizenRepo: CitizenAppRegistrationRepository
+
     @Autowired private lateinit var dcCaseRepo: DcCaseRepository
+
     @Autowired private lateinit var dcIncomeRepo: DcIncomeRepository
+
     @Autowired private lateinit var dcEducationRepo: DcEducationRepository
+
     @Autowired private lateinit var dcChildrenRepo: DcChildrenRepository
+
     @Autowired private lateinit var eligibilityRepository: EligibilityDetailsRepository
+
     @Autowired private lateinit var coTriggerRepository: CoTriggerRepository
+
     @Autowired private lateinit var planRuleRepository: com.lakshay.healthcare.shared.repository.PlanRuleRepository
+
     @Autowired
     private lateinit var householdMemberRepository: com.lakshay.healthcare.shared.repository.HouseholdMemberRepository
 
@@ -172,8 +181,11 @@ class EligibilityMatrixIT : IntegrationTestBase() {
     fun `ELIG-MATRIX case with no plan selected throws`() {
         val app = citizenRepo.save(
             CitizenAppRegistration(
-                fullName = "No Plan", email = "noplan@ish.test", gender = "M",
-                ssn = 111111111L, stateName = "California"
+                fullName = "No Plan",
+                email = "noplan@ish.test",
+                gender = "M",
+                ssn = 111111111L,
+                stateName = "California"
             )
         )
         val caseNo = dcCaseRepo.save(DcCase(appId = app.appId, planId = null)).caseNo
@@ -188,8 +200,11 @@ class EligibilityMatrixIT : IntegrationTestBase() {
     fun `ELIG-MATRIX case referencing a missing plan throws`() {
         val app = citizenRepo.save(
             CitizenAppRegistration(
-                fullName = "Bad Plan", email = "badplan@ish.test", gender = "M",
-                ssn = 222222222L, stateName = "California"
+                fullName = "Bad Plan",
+                email = "badplan@ish.test",
+                gender = "M",
+                ssn = 222222222L,
+                stateName = "California"
             )
         )
         val caseNo = dcCaseRepo.save(DcCase(appId = app.appId, planId = 888_888L)).caseNo
@@ -204,8 +219,11 @@ class EligibilityMatrixIT : IntegrationTestBase() {
     fun `ELIG-MATRIX case with no income data throws`() {
         val app = citizenRepo.save(
             CitizenAppRegistration(
-                fullName = "No Income", email = "noincome@ish.test", gender = "F",
-                ssn = 333333333L, stateName = "California"
+                fullName = "No Income",
+                email = "noincome@ish.test",
+                gender = "F",
+                ssn = 333333333L,
+                stateName = "California"
             )
         )
         val caseNo = dcCaseRepo.save(DcCase(appId = app.appId, planId = planId("SNAP"))).caseNo
@@ -245,7 +263,9 @@ class EligibilityMatrixIT : IntegrationTestBase() {
         val caseNo = seedCase(planName = "SNAP", empIncome = 250.0)
         householdMemberRepository.save(
             com.lakshay.healthcare.shared.entity.HouseholdMember(
-                caseNo = caseNo, relationship = "SPOUSE", memberIncome = 100.0
+                caseNo = caseNo,
+                relationship = "SPOUSE",
+                memberIncome = 100.0
             )
         )
         val result = eligibilityService.determineEligibility(caseNo)
@@ -272,61 +292,170 @@ class EligibilityMatrixIT : IntegrationTestBase() {
     companion object {
         const val FALLBACK_PLAN = "OTHER"
 
+        // LongMethod: test data table — one Row per rule branch, one-arg-per-line after ktlint wrapping.
+        @Suppress("LongMethod")
         @JvmStatic
         fun matrixRows(): List<Arguments> = listOf(
             // SNAP: empIncome < 300
-            Row("SNAP approved (income 100)", "SNAP", empIncome = 100.0,
-                expectedStatus = "APPROVED", expectedBenefit = 200.0),
-            Row("SNAP denied (income 500)", "SNAP", empIncome = 500.0,
-                expectedStatus = "DENIED", expectedDenial = "High Income"),
-            Row("SNAP boundary income==300 is denied", "SNAP", empIncome = 300.0,
-                expectedStatus = "DENIED", expectedDenial = "High Income"),
+            Row(
+                "SNAP approved (income 100)",
+                "SNAP",
+                empIncome = 100.0,
+                expectedStatus = "APPROVED",
+                expectedBenefit = 200.0
+            ),
+            Row(
+                "SNAP denied (income 500)",
+                "SNAP",
+                empIncome = 500.0,
+                expectedStatus = "DENIED",
+                expectedDenial = "High Income"
+            ),
+            Row(
+                "SNAP boundary income==300 is denied",
+                "SNAP",
+                empIncome = 300.0,
+                expectedStatus = "DENIED",
+                expectedDenial = "High Income"
+            ),
 
             // CCAP: income < 300 && has kids && all kids age <= 16
-            Row("CCAP approved (income 100, one kid age 5)", "CCAP", empIncome = 100.0, childAges = listOf(5),
-                expectedStatus = "APPROVED", expectedBenefit = 300.0),
-            Row("CCAP denied (no children)", "CCAP", empIncome = 100.0,
-                expectedStatus = "DENIED", expectedDenial = "CCAP rules are not satisfied"),
-            Row("CCAP denied (a kid over 16)", "CCAP", empIncome = 100.0, childAges = listOf(17),
-                expectedStatus = "DENIED", expectedDenial = "CCAP rules are not satisfied"),
-            Row("CCAP boundary kid age==16 approved", "CCAP", empIncome = 100.0, childAges = listOf(16),
-                expectedStatus = "APPROVED", expectedBenefit = 300.0),
+            Row(
+                "CCAP approved (income 100, one kid age 5)",
+                "CCAP",
+                empIncome = 100.0,
+                childAges = listOf(5),
+                expectedStatus = "APPROVED",
+                expectedBenefit = 300.0
+            ),
+            Row(
+                "CCAP denied (no children)",
+                "CCAP",
+                empIncome = 100.0,
+                expectedStatus = "DENIED",
+                expectedDenial = "CCAP rules are not satisfied"
+            ),
+            Row(
+                "CCAP denied (a kid over 16)",
+                "CCAP",
+                empIncome = 100.0,
+                childAges = listOf(17),
+                expectedStatus = "DENIED",
+                expectedDenial = "CCAP rules are not satisfied"
+            ),
+            Row(
+                "CCAP boundary kid age==16 approved",
+                "CCAP",
+                empIncome = 100.0,
+                childAges = listOf(16),
+                expectedStatus = "APPROVED",
+                expectedBenefit = 300.0
+            ),
 
             // MEDCARE: age >= 65
-            Row("MEDCARE approved (age 70)", "MEDCARE", age = 70,
-                expectedStatus = "APPROVED", expectedBenefit = 350.0),
-            Row("MEDCARE denied (age 40)", "MEDCARE", age = 40,
-                expectedStatus = "DENIED", expectedDenial = "MEDCARE rules are not satisfied"),
-            Row("MEDCARE boundary age==65 approved", "MEDCARE", age = 65,
-                expectedStatus = "APPROVED", expectedBenefit = 350.0),
+            Row(
+                "MEDCARE approved (age 70)",
+                "MEDCARE",
+                age = 70,
+                expectedStatus = "APPROVED",
+                expectedBenefit = 350.0
+            ),
+            Row(
+                "MEDCARE denied (age 40)",
+                "MEDCARE",
+                age = 40,
+                expectedStatus = "DENIED",
+                expectedDenial = "MEDCARE rules are not satisfied"
+            ),
+            Row(
+                "MEDCARE boundary age==65 approved",
+                "MEDCARE",
+                age = 65,
+                expectedStatus = "APPROVED",
+                expectedBenefit = 350.0
+            ),
 
             // MEDAID: income < 300 && propertyIncome == 0
-            Row("MEDAID approved (income 100, no property)", "MEDAID", empIncome = 100.0, propertyIncome = 0.0,
-                expectedStatus = "APPROVED", expectedBenefit = 200.0),
-            Row("MEDAID denied (has property income)", "MEDAID", empIncome = 100.0, propertyIncome = 50.0,
-                expectedStatus = "DENIED", expectedDenial = "MEDAID rules are not satisfied"),
+            Row(
+                "MEDAID approved (income 100, no property)",
+                "MEDAID",
+                empIncome = 100.0,
+                propertyIncome = 0.0,
+                expectedStatus = "APPROVED",
+                expectedBenefit = 200.0
+            ),
+            Row(
+                "MEDAID denied (has property income)",
+                "MEDAID",
+                empIncome = 100.0,
+                propertyIncome = 50.0,
+                expectedStatus = "DENIED",
+                expectedDenial = "MEDAID rules are not satisfied"
+            ),
 
             // CAJW: empIncome == 0 && passOutYear <= thisYear
-            Row("CAJW approved (no income, passed out)", "CAJW", empIncome = 0.0, passOutYear = 2020,
-                expectedStatus = "APPROVED", expectedBenefit = 300.0),
-            Row("CAJW denied (has income)", "CAJW", empIncome = 10.0, passOutYear = 2020,
-                expectedStatus = "DENIED", expectedDenial = "CAJW rules are not satisfied"),
-            Row("CAJW denied (no education record)", "CAJW", empIncome = 0.0,
-                expectedStatus = "DENIED", expectedDenial = "CAJW rules are not satisfied"),
+            Row(
+                "CAJW approved (no income, passed out)",
+                "CAJW",
+                empIncome = 0.0,
+                passOutYear = 2020,
+                expectedStatus = "APPROVED",
+                expectedBenefit = 300.0
+            ),
+            Row(
+                "CAJW denied (has income)",
+                "CAJW",
+                empIncome = 10.0,
+                passOutYear = 2020,
+                expectedStatus = "DENIED",
+                expectedDenial = "CAJW rules are not satisfied"
+            ),
+            Row(
+                "CAJW denied (no education record)",
+                "CAJW",
+                empIncome = 0.0,
+                expectedStatus = "DENIED",
+                expectedDenial = "CAJW rules are not satisfied"
+            ),
 
             // QHP: age >= 25, approval carries no benefit amount
-            Row("QHP approved (age 30, no benefit amount)", "QHP", age = 30,
-                expectedStatus = "APPROVED", expectedBenefit = null),
-            Row("QHP denied (age 20)", "QHP", age = 20,
-                expectedStatus = "DENIED", expectedDenial = "QHP rules are not satisfied"),
-            Row("QHP boundary age==25 approved", "QHP", age = 25,
-                expectedStatus = "APPROVED", expectedBenefit = null),
+            Row(
+                "QHP approved (age 30, no benefit amount)",
+                "QHP",
+                age = 30,
+                expectedStatus = "APPROVED",
+                expectedBenefit = null
+            ),
+            Row(
+                "QHP denied (age 20)",
+                "QHP",
+                age = 20,
+                expectedStatus = "DENIED",
+                expectedDenial = "QHP rules are not satisfied"
+            ),
+            Row(
+                "QHP boundary age==25 approved",
+                "QHP",
+                age = 25,
+                expectedStatus = "APPROVED",
+                expectedBenefit = null
+            ),
 
             // Fallback else-branch: total income < 10000 -> 10% benefit
-            Row("OTHER approved (income 5000 -> 10% = 500)", FALLBACK_PLAN, empIncome = 5000.0,
-                expectedStatus = "APPROVED", expectedBenefit = 500.0),
-            Row("OTHER denied (income 20000)", FALLBACK_PLAN, empIncome = 20000.0,
-                expectedStatus = "DENIED", expectedDenial = "Eligibility rules not satisfied for OTHER")
+            Row(
+                "OTHER approved (income 5000 -> 10% = 500)",
+                FALLBACK_PLAN,
+                empIncome = 5000.0,
+                expectedStatus = "APPROVED",
+                expectedBenefit = 500.0
+            ),
+            Row(
+                "OTHER denied (income 20000)",
+                FALLBACK_PLAN,
+                empIncome = 20000.0,
+                expectedStatus = "DENIED",
+                expectedDenial = "Eligibility rules not satisfied for OTHER"
+            )
         ).map { Arguments.of(it) }
     }
 }

--- a/healthcare/src/test/kotlin/com/lakshay/healthcare/EligibilityScreeningIT.kt
+++ b/healthcare/src/test/kotlin/com/lakshay/healthcare/EligibilityScreeningIT.kt
@@ -18,13 +18,19 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 class EligibilityScreeningIT : IntegrationTestBase() {
 
     @Autowired private lateinit var citizenRepo: CitizenAppRegistrationRepository
+
     @Autowired private lateinit var dcCaseRepo: DcCaseRepository
+
     @Autowired private lateinit var dcIncomeRepo: DcIncomeRepository
 
     private fun seedCaseWithIncome(email: String, empIncome: Double? = 100.0): Long {
         val app = citizenRepo.save(
             CitizenAppRegistration(
-                fullName = "Jane Doe", email = email, gender = "F", ssn = 123456704L, stateName = "California"
+                fullName = "Jane Doe",
+                email = email,
+                gender = "F",
+                ssn = 123456704L,
+                stateName = "California"
             )
         )
         val caseNo = dcCaseRepo.save(DcCase(appId = app.appId)).caseNo
@@ -46,16 +52,20 @@ class EligibilityScreeningIT : IntegrationTestBase() {
     @Test
     fun `citizen screens own case`() {
         val caseNo = seedCaseWithIncome("owner@ish.test", 100.0)
-        mockMvc.perform(get("/ed-api/screen/$caseNo")
-            .header(HttpHeaders.AUTHORIZATION, bearer("ROLE_CITIZEN", "owner@ish.test")))
+        mockMvc.perform(
+            get("/ed-api/screen/$caseNo")
+                .header(HttpHeaders.AUTHORIZATION, bearer("ROLE_CITIZEN", "owner@ish.test"))
+        )
             .andExpect(status().isOk)
     }
 
     @Test
     fun `citizen cannot screen another citizens case`() {
         val caseNo = seedCaseWithIncome("owner@ish.test", 100.0)
-        mockMvc.perform(get("/ed-api/screen/$caseNo")
-            .header(HttpHeaders.AUTHORIZATION, bearer("ROLE_CITIZEN", "intruder@ish.test")))
+        mockMvc.perform(
+            get("/ed-api/screen/$caseNo")
+                .header(HttpHeaders.AUTHORIZATION, bearer("ROLE_CITIZEN", "intruder@ish.test"))
+        )
             .andExpect(status().isForbidden)
     }
 

--- a/healthcare/src/test/kotlin/com/lakshay/healthcare/GoldenLifecycleIT.kt
+++ b/healthcare/src/test/kotlin/com/lakshay/healthcare/GoldenLifecycleIT.kt
@@ -30,7 +30,9 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 class GoldenLifecycleIT : IntegrationTestBase() {
 
     @Autowired lateinit var citizenRepository: CitizenAppRegistrationRepository
+
     @Autowired lateinit var eligibilityRepository: EligibilityDetailsRepository
+
     @Autowired lateinit var coTriggerRepository: CoTriggerRepository
 
     @Test
@@ -109,7 +111,7 @@ class GoldenLifecycleIT : IntegrationTestBase() {
 
         val trigger = coTriggerRepository.findByCaseNo(caseNo)
         assertThat(trigger).isNotNull
-        assertThat(trigger!!.triggerStatus).isEqualTo("PENDING")  // couples to correspondence
+        assertThat(trigger!!.triggerStatus).isEqualTo("PENDING") // couples to correspondence
 
         // correspondence: consume PENDING trigger, email citizen, mark PROCESSED
         mockMvc.perform(
@@ -130,7 +132,7 @@ class GoldenLifecycleIT : IntegrationTestBase() {
 
         val processedTrigger = coTriggerRepository.findByCaseNo(caseNo)
         assertThat(processedTrigger!!.triggerStatus).isEqualTo("PROCESSED")
-        assertThat(processedTrigger.coNoticePdf).isNotNull  // PDF persisted
+        assertThat(processedTrigger.coNoticePdf).isNotNull // PDF persisted
 
         // benefit batch: APPROVED rows -> CSV
         mockMvc.perform(
@@ -143,9 +145,9 @@ class GoldenLifecycleIT : IntegrationTestBase() {
 
         assertThat(BENEFIT_OUTPUT_FILE).exists()
         val csv = BENEFIT_OUTPUT_FILE.readText()
-        assertThat(csv).contains("Case No,Holder Name,SSN")  // header
+        assertThat(csv).contains("Case No,Holder Name,SSN") // header
         assertThat(csv).contains(caseNo.toString())
-        assertThat(csv).contains("ISH-Bank")                 // processor-assigned bank
+        assertThat(csv).contains("ISH-Bank") // processor-assigned bank
 
         // govt report: 1 app, 1 approved, 0 denied
         mockMvc.perform(

--- a/healthcare/src/test/kotlin/com/lakshay/healthcare/GovernmentReportIT.kt
+++ b/healthcare/src/test/kotlin/com/lakshay/healthcare/GovernmentReportIT.kt
@@ -31,7 +31,9 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 class GovernmentReportIT : IntegrationTestBase() {
 
     @Autowired private lateinit var reportRepository: GovernmentReportRepository
+
     @Autowired private lateinit var citizenRepo: CitizenAppRegistrationRepository
+
     @Autowired private lateinit var eligibilityRepository: EligibilityDetailsRepository
 
     /** Seed [citizens] applications (= "total applications") plus [approved]/[denied] eligibility rows. */
@@ -39,8 +41,11 @@ class GovernmentReportIT : IntegrationTestBase() {
         repeat(citizens) { i ->
             citizenRepo.save(
                 CitizenAppRegistration(
-                    fullName = "Citizen $i", email = "c$i@ish.test", gender = "F",
-                    ssn = 100000000L + i, stateName = "California"
+                    fullName = "Citizen $i",
+                    email = "c$i@ish.test",
+                    gender = "F",
+                    ssn = 100000000L + i,
+                    stateName = "California"
                 )
             )
         }
@@ -52,7 +57,10 @@ class GovernmentReportIT : IntegrationTestBase() {
         repeat(denied) { i ->
             eligibilityRepository.save(
                 EligibilityDetails(
-                    caseNo = 2000L + i, planName = "SNAP", planStatus = "DENIED", denialReason = "High Income"
+                    caseNo = 2000L + i,
+                    planName = "SNAP",
+                    planStatus = "DENIED",
+                    denialReason = "High Income"
                 )
             )
         }
@@ -69,8 +77,12 @@ class GovernmentReportIT : IntegrationTestBase() {
             .content(json(ReportRequest(reportType, reportFormat, periodCovered, departmentName = departmentName)))
     )
 
-    private fun generatedId(reportType: String = "MONTHLY", reportFormat: String = "TEXT",
-                            periodCovered: String? = "JUNE", departmentName: String? = "Health Dept"): Long {
+    private fun generatedId(
+        reportType: String = "MONTHLY",
+        reportFormat: String = "TEXT",
+        periodCovered: String? = "JUNE",
+        departmentName: String? = "Health Dept"
+    ): Long {
         val body = generate(reportType, reportFormat, periodCovered, departmentName)
             .andExpect(status().isCreated).andReturn().response.contentAsString
         return objectMapper.readTree(body).get("reportId").asLong()

--- a/healthcare/src/test/kotlin/com/lakshay/healthcare/HouseholdIT.kt
+++ b/healthcare/src/test/kotlin/com/lakshay/healthcare/HouseholdIT.kt
@@ -18,13 +18,17 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers.status
 class HouseholdIT : IntegrationTestBase() {
 
     @Autowired private lateinit var citizenRepo: CitizenAppRegistrationRepository
+
     @Autowired private lateinit var dcCaseRepo: DcCaseRepository
 
     private fun seedCase(): Long {
         val app = citizenRepo.save(
             CitizenAppRegistration(
-                fullName = "Jane Doe", email = "citizen@ish.test", gender = "F",
-                ssn = 123456704L, stateName = "California"
+                fullName = "Jane Doe",
+                email = "citizen@ish.test",
+                gender = "F",
+                ssn = 123456704L,
+                stateName = "California"
             )
         )
         return dcCaseRepo.save(DcCase(appId = app.appId)).caseNo
@@ -37,12 +41,17 @@ class HouseholdIT : IntegrationTestBase() {
         mockMvc.perform(
             post("/dc-api/saveHouseholdMember").header(HttpHeaders.AUTHORIZATION, adminAuth())
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(json(
-                    HouseholdMemberRequest(
-                        caseNo = caseNo, fullName = "John Doe", relationship = "SPOUSE",
-                        dob = "1988-05-01", memberIncome = 0.0
+                .content(
+                    json(
+                        HouseholdMemberRequest(
+                            caseNo = caseNo,
+                            fullName = "John Doe",
+                            relationship = "SPOUSE",
+                            dob = "1988-05-01",
+                            memberIncome = 0.0
+                        )
                     )
-                ))
+                )
         )
             .andExpect(status().isOk)
             .andExpect(jsonPath("$.memberId").isNumber)

--- a/healthcare/src/test/kotlin/com/lakshay/healthcare/PlanManagementIT.kt
+++ b/healthcare/src/test/kotlin/com/lakshay/healthcare/PlanManagementIT.kt
@@ -38,9 +38,15 @@ class PlanManagementIT : IntegrationTestBase() {
         mockMvc.perform(
             post("/plan-api/register").header(HttpHeaders.AUTHORIZATION, adminAuth())
                 .contentType(MediaType.APPLICATION_JSON)
-                .content(json(PlanRequest(
-                    planName = "NEWPLAN", description = "A new plan", categoryId = seededCategoryId
-                )))
+                .content(
+                    json(
+                        PlanRequest(
+                            planName = "NEWPLAN",
+                            description = "A new plan",
+                            categoryId = seededCategoryId
+                        )
+                    )
+                )
         )
             .andExpect(status().isCreated)
             .andExpect(jsonPath("$.message", containsString("registered successfully")))

--- a/healthcare/src/test/kotlin/com/lakshay/healthcare/StatusEmailIT.kt
+++ b/healthcare/src/test/kotlin/com/lakshay/healthcare/StatusEmailIT.kt
@@ -20,17 +20,25 @@ import org.springframework.beans.factory.annotation.Autowired
 class StatusEmailIT : IntegrationTestBase() {
 
     @Autowired lateinit var eligibilityService: EligibilityDeterminationService
+
     @Autowired lateinit var caseworkService: CaseworkService
+
     @Autowired lateinit var citizenRepo: CitizenAppRegistrationRepository
+
     @Autowired lateinit var dcCaseRepo: DcCaseRepository
+
     @Autowired lateinit var dcIncomeRepo: DcIncomeRepository
+
     @Autowired lateinit var noticeRepository: NoticeRepository
 
     private fun seedCase(empIncome: Double): Long {
         val app = citizenRepo.save(
             CitizenAppRegistration(
-                fullName = "Jane Doe", email = "jane@ish.test", gender = "F",
-                ssn = 123456704L, stateName = "California"
+                fullName = "Jane Doe",
+                email = "jane@ish.test",
+                gender = "F",
+                ssn = 123456704L,
+                stateName = "California"
             )
         )
         val case = dcCaseRepo.save(DcCase(appId = app.appId, planId = planId("SNAP")))

--- a/healthcare/src/test/kotlin/com/lakshay/healthcare/shared/notification/StatusEmailTemplateTests.kt
+++ b/healthcare/src/test/kotlin/com/lakshay/healthcare/shared/notification/StatusEmailTemplateTests.kt
@@ -12,24 +12,36 @@ import kotlin.test.assertTrue
 class StatusEmailTemplateTests {
 
     private val engine = SpringTemplateEngine().apply {
-        setTemplateResolver(ClassLoaderTemplateResolver().apply {
-            prefix = "templates/"
-            suffix = ".html"
-            templateMode = TemplateMode.HTML
-        })
+        setTemplateResolver(
+            ClassLoaderTemplateResolver().apply {
+                prefix = "templates/"
+                suffix = ".html"
+                templateMode = TemplateMode.HTML
+            }
+        )
     }
 
     private fun render(model: Map<String, Any?>): String =
         engine.process("mail/status-change", Context().apply { setVariables(model) })
 
     private fun baseModel(status: String) = mutableMapOf<String, Any?>(
-        "citizenName" to "Jane Doe", "caseNo" to 42L, "status" to status,
-        "planName" to null, "benefitAmt" to null, "denialReason" to null, "message" to null
+        "citizenName" to "Jane Doe",
+        "caseNo" to 42L,
+        "status" to status,
+        "planName" to null,
+        "benefitAmt" to null,
+        "denialReason" to null,
+        "message" to null
     )
 
     @Test
     fun `approved shows plan and amount`() {
-        val html = render(baseModel("APPROVED").apply { put("planName", "SNAP"); put("benefitAmt", 200.0) })
+        val html = render(
+            baseModel("APPROVED").apply {
+                put("planName", "SNAP")
+                put("benefitAmt", 200.0)
+            }
+        )
         assertContains(html, "Jane Doe")
         assertContains(html, "SNAP")
         assertContains(html, "approved")
@@ -46,7 +58,12 @@ class StatusEmailTemplateTests {
 
     @Test
     fun `denied shows reason`() {
-        val html = render(baseModel("DENIED").apply { put("planName", "SNAP"); put("denialReason", "High Income") })
+        val html = render(
+            baseModel("DENIED").apply {
+                put("planName", "SNAP")
+                put("denialReason", "High Income")
+            }
+        )
         assertContains(html, "denied")
         assertContains(html, "High Income")
         assertFalse(html.contains("approved"))
@@ -62,7 +79,10 @@ class StatusEmailTemplateTests {
     @Test
     fun `html in model values is escaped`() {
         val html = render(
-            baseModel("DENIED").apply { put("planName", "SNAP"); put("denialReason", "<script>alert(1)</script>") }
+            baseModel("DENIED").apply {
+                put("planName", "SNAP")
+                put("denialReason", "<script>alert(1)</script>")
+            }
         )
         assertTrue(html.contains("&lt;script&gt;"))
         assertFalse(html.contains("<script>alert"))

--- a/healthcare/src/test/kotlin/com/lakshay/healthcare/support/IntegrationTestBase.kt
+++ b/healthcare/src/test/kotlin/com/lakshay/healthcare/support/IntegrationTestBase.kt
@@ -87,19 +87,33 @@ abstract class IntegrationTestBase {
     }
 
     @Autowired protected lateinit var mockMvc: MockMvc
+
     @Autowired protected lateinit var objectMapper: ObjectMapper
+
     @Autowired protected lateinit var jwtUtil: JwtUtil
+
     @Autowired protected lateinit var jdbc: JdbcTemplate
+
     @Autowired protected lateinit var passwordEncoder: PasswordEncoder
+
     @Autowired protected lateinit var adminRepository: AdminMasterRepository
+
     @Autowired protected lateinit var categoryRepository: PlanCategoryRepository
+
     @Autowired protected lateinit var planRepository: PlanRepository
+
     @Autowired protected lateinit var userRepository: UserMasterRepository
+
     @Autowired protected lateinit var workerRepository: WorkerMasterRepository
 
-    @Value("\${jwt.secret}") protected lateinit var jwtSecret: String
-    @Value("\${jwt.issuer}") protected lateinit var jwtIssuer: String
-    @Value("\${jwt.audience}") protected lateinit var jwtAudience: String
+    @Value("\${jwt.secret}")
+    protected lateinit var jwtSecret: String
+
+    @Value("\${jwt.issuer}")
+    protected lateinit var jwtIssuer: String
+
+    @Value("\${jwt.audience}")
+    protected lateinit var jwtAudience: String
 
     @MockBean protected lateinit var mailSender: JavaMailSender
 
@@ -153,7 +167,10 @@ abstract class IntegrationTestBase {
      * it; this RequestPostProcessor mirrors that. Only needed on token-less requests.
      */
     protected fun servletPath(path: String): RequestPostProcessor =
-        RequestPostProcessor { req -> req.servletPath = path; req }
+        RequestPostProcessor { req ->
+            req.servletPath = path
+            req
+        }
 
     /** Seed an activated USER with a bcrypt-hashed [rawPassword]. Returns the saved entity. */
     protected fun seedUser(


### PR DESCRIPTION
Closes the gap between IDE detekt (runs the formatting/ktlint ruleset) and the Maven build (default rules only) — that's why `main` read clean while IntelliJ still flagged tabs/wrapping.

- Added `detekt-formatting` 1.23.7 to the detekt plugin. `check` verifies only; reformat via IDE or `-DautoCorrect=true`.
- Auto-formatted **40 files** — 464 formatting findings -> 0. Mostly ArgumentListWrapping (one arg per line), import ordering, spacing, `HealthcareApplication` tabs->spaces, stray semicolons.
- One `@Suppress("LongMethod")` on the `matrixRows` parameterized-test data table.

**Formatting only, no behavior change.** `detekt:check` BUILD SUCCESS (0), compile + test-compile clean, GoldenLifecycleIT 3/3 green. Big but mechanical diff.