### PR TITLE
fix: clear compiler warnings (deprecations + dead code)

### DIFF
--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/data/service/DataCollectionService.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/data/service/DataCollectionService.kt
@@ -41,7 +41,7 @@ class DataCollectionService(
 ) {
 
     fun loadCaseNo(appId: Long): CaseResponse {
-        val citizen = citizenRepository.findByAppId(appId)
+        citizenRepository.findByAppId(appId)
             ?: throw ResourceNotFoundException("Citizen application not found for ID: $appId")
 
         if (dcCaseRepository.findByAppId(appId) != null) {

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/security/RateLimitFilter.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/shared/security/RateLimitFilter.kt
@@ -2,9 +2,7 @@ package com.lakshay.healthcare.shared.security
 
 import com.github.benmanes.caffeine.cache.Caffeine
 import com.github.benmanes.caffeine.cache.LoadingCache
-import io.github.bucket4j.Bandwidth
 import io.github.bucket4j.Bucket
-import io.github.bucket4j.Refill
 import jakarta.servlet.FilterChain
 import jakarta.servlet.http.HttpServletRequest
 import jakarta.servlet.http.HttpServletResponse
@@ -39,7 +37,7 @@ class RateLimitFilter(
         .maximumSize(CACHE_MAX_SIZE) // spoofed-IP flood shouldn't OOM us
         .build { _ ->
             Bucket.builder()
-                .addLimit(Bandwidth.classic(limit, Refill.intervally(limit, window)))
+                .addLimit { it.capacity(limit).refillIntervally(limit, window) }
                 .build()
         }
 

--- a/healthcare/src/main/kotlin/com/lakshay/healthcare/user/controller/AuthController.kt
+++ b/healthcare/src/main/kotlin/com/lakshay/healthcare/user/controller/AuthController.kt
@@ -42,8 +42,8 @@ class AuthController(
             throw AccountLockedException(loginAttemptService.lockoutSeconds())
         }
         return try {
-            var name = ""
-            var userType = "USER"
+            var name: String
+            var userType: String
 
             val admin = adminRepository.findByEmail(request.email)
             if (admin != null) {

--- a/healthcare/src/test/kotlin/com/lakshay/healthcare/support/IntegrationTestBase.kt
+++ b/healthcare/src/test/kotlin/com/lakshay/healthcare/support/IntegrationTestBase.kt
@@ -216,12 +216,12 @@ abstract class IntegrationTestBase {
         audience: String = jwtAudience,
         expiry: Date = Date(System.currentTimeMillis() + 60_000)
     ): String = Jwts.builder()
-        .setSubject(email)
+        .subject(email)
         .claim("role", role)
-        .setIssuer(issuer)
-        .setAudience(audience)
-        .setIssuedAt(Date())
-        .setExpiration(expiry)
+        .issuer(issuer)
+        .audience().add(audience).and()
+        .issuedAt(Date())
+        .expiration(expiry)
         .signWith(Keys.hmacShaKeyFor(jwtSecret.toByteArray(StandardCharsets.UTF_8)))
         .compact()
 }


### PR DESCRIPTION
Resolves all 12 kotlinc build warnings.

- **bucket4j** (RateLimitFilter): `Bandwidth.classic`/`Refill.intervally` -> `addLimit { it.capacity(limit).refillIntervally(limit, window) }` (builder API, same behavior).
- **jjwt** (IntegrationTestBase.forgeToken): deprecated `setSubject/setIssuer/setAudience/setIssuedAt/setExpiration` -> 0.12 fluent API, mirroring JwtUtil.
- **dead code** (DataCollectionService): dropped unused `citizen` binding, kept the existence check.
- **redundant initializers** (AuthController.login): `var name/userType` — removed always-overwritten inits.

Warning-free build. Verified: detekt BUILD SUCCESS, AuthIT 22/22, RateLimitingTests 5/5.